### PR TITLE
Adding os-independent file copy/delete modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,5 @@ jspm_packages
 quickstart/public/index.js
 examples/mediadevices/public/index.js
 
-# The generated snippet.js
-examples/mediadevices/public/snippet.js
+# The generated helpers.js
+examples/mediadevices/public/helpers.js

--- a/examples/mediadevices/src/index.js
+++ b/examples/mediadevices/src/index.js
@@ -44,7 +44,7 @@ function updateDeviceSelectionOptions() {
 }
 
 // Load the code snippet.
-getSnippet('./snippet.js').then(function(snippet) {
+getSnippet('./helpers.js').then(function(snippet) {
   var pre = document.querySelector('pre.language-javascript');
   pre.innerHTML = Prism.highlight(snippet, Prism.languages.javascript);
 });

--- a/package.json
+++ b/package.json
@@ -1,15 +1,17 @@
 {
   "name": "video-quickstart-js",
-  "version": "1.0.0-dev",
+  "version": "1.0.0",
   "description": "Twilio Video SDK Quick Start for JavaScript",
   "main": "index.js",
   "scripts": {
-    "clean": "npm run clean:quickstart",
-    "clean:quickstart": "rm -rf quickstart/public/index.js examples/mediadevices/public/index.js",
+    "clean": "npm run clean:quickstart && npm run clean:examples",
+    "clean:quickstart": "rimraf quickstart/public/index.js",
+    "clean:examples": "npm run clean:examples:mediadevices",
+    "clean:examples:mediadevices": "rimraf examples/mediadevices/public/index.js examples/mediadevices/public/helpers.js",
     "build": "npm run build:quickstart && npm run build:examples",
     "build:examples": "npm run build:example:mediadevices",
-    "build:example:mediadevices": "cp examples/mediadevices/src/helpers.js examples/mediadevices/public/snippet.js && ./node_modules/.bin/browserify examples/mediadevices/src/index.js > examples/mediadevices/public/index.js",
-    "build:quickstart": "./node_modules/.bin/browserify quickstart/src/index.js > quickstart/public/index.js",
+    "build:example:mediadevices": "copyfiles -f examples/mediadevices/src/helpers.js examples/mediadevices/public && browserify examples/mediadevices/src/index.js > examples/mediadevices/public/index.js",
+    "build:quickstart": "browserify quickstart/src/index.js > quickstart/public/index.js",
     "start": "npm run clean && npm run build && node server"
   },
   "repository": {
@@ -39,6 +41,8 @@
     "twilio-video": "^1.0.0"
   },
   "devDependencies": {
-    "browserify": "^14.3.0"
+    "browserify": "^14.3.0",
+    "copyfiles": "^1.2.0",
+    "rimraf": "^2.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "video-quickstart-js",
-  "version": "1.0.0",
+  "version": "1.0.0-dev",
   "description": "Twilio Video SDK Quick Start for JavaScript",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@markandrus 

We're now using `copyfiles` and `rimraf` modules for file copy/delete.
This should work on windows as well.