### PR TITLE
Added cp alternative for Windows to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,14 @@ or possibly your `~/.bash_profile`.
 ## Setting Up The Application
 
 Create a configuration file for your application:
+On Mac or Linux distributions
 ```bash
 cp .env.template .env
 ```
-
+On windows use the command
+```bash
+xcopy .env.template .env
+```
 Edit `.env` with the configuration parameters we gathered from above.
 
 Next, we need to install our dependencies from npm:


### PR DESCRIPTION
'cp' is not recognized as an internal or external command, operable program or batch file on windows. Windows users must use "xcopy" instead