### PR TITLE
explicitly call getuserMedia before enumerateDevices

### DIFF
--- a/examples/mediadevices/src/helpers.js
+++ b/examples/mediadevices/src/helpers.js
@@ -97,12 +97,16 @@ function applyVideoInputDeviceSelection(deviceId, video, room) {
  * @property {Array<MediaDeviceInfo>} videoinput
  */
 function getDeviceSelectionOptions() {
-  return navigator.mediaDevices.enumerateDevices().then(function(deviceInfos) {
-    var kinds = ['audioinput', 'audiooutput', 'videoinput'];
-    return kinds.reduce(function(deviceSelectionOptions, kind) {
-      deviceSelectionOptions[kind] = getDevicesOfKind(deviceInfos, kind);
-      return deviceSelectionOptions;
-    }, {});
+  // before calling enumerateDevices, get media permissions (.getUserMedia)
+  // w/o media permissions, browsers do not return device Ids.
+  return navigator.mediaDevices.getUserMedia({ audio: true, video: true }).then(() => {
+    return navigator.mediaDevices.enumerateDevices().then(function(deviceInfos) {
+      var kinds = ['audioinput', 'audiooutput', 'videoinput'];
+      return kinds.reduce(function(deviceSelectionOptions, kind) {
+        deviceSelectionOptions[kind] = getDevicesOfKind(deviceInfos, kind);
+        return deviceSelectionOptions;
+      }, {});
+    });
   });
 }
 

--- a/examples/mediadevices/src/index.js
+++ b/examples/mediadevices/src/index.js
@@ -27,11 +27,7 @@ var deviceSelections = {
  * Build the list of available media devices.
  */
 function updateDeviceSelectionOptions() {
-  // before enumerating devices, get media permssions
-  // NOTE: w/o media permissions, safari/ff does not return the labels
-  // (like front camera, back camera) for the devices.
-  return navigator.mediaDevices.getUserMedia({ audio: true, video: true })
-    .then(getDeviceSelectionOptions)
+  return getDeviceSelectionOptions({ audio: true, video: true })
     .then(function(deviceSelectionOptions) {
       ['audioinput', 'audiooutput', 'videoinput'].forEach(function(kind) {
           var kindDeviceInfos = deviceSelectionOptions[kind];

--- a/examples/mediadevices/src/index.js
+++ b/examples/mediadevices/src/index.js
@@ -27,7 +27,7 @@ var deviceSelections = {
  * Build the list of available media devices.
  */
 function updateDeviceSelectionOptions() {
-  return getDeviceSelectionOptions({ audio: true, video: true })
+  return getDeviceSelectionOptions()
     .then(function(deviceSelectionOptions) {
       ['audioinput', 'audiooutput', 'videoinput'].forEach(function(kind) {
           var kindDeviceInfos = deviceSelectionOptions[kind];


### PR DESCRIPTION
Safari and Firefox already required media permission for full use of `enumerateDevices`, now [chrome joins](https://crbug.com/1019176) the pack. Make it explicit in this  sample.  

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
