### PR TITLE
[FIX] Fixed API_KEY to API_SID in env file

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,3 @@
 TWILIO_ACCOUNT_SID=ACxxxxxxxxxx
-TWILIO_API_KEY=SKxxxxxxxxxx
+TWILIO_API_SID=SKxxxxxxxxxx
 TWILIO_API_SECRET=xxxxxxxxxx

--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,3 @@
 TWILIO_ACCOUNT_SID=ACxxxxxxxxxx
-TWILIO_API_SID=SKxxxxxxxxxx
+TWILIO_API_KEY=SKxxxxxxxxxx
 TWILIO_API_SECRET=xxxxxxxxxx

--- a/server/index.js
+++ b/server/index.js
@@ -67,7 +67,7 @@ app.get('/token', function(request, response) {
   // containing the grant we just created.
   var token = new AccessToken(
     process.env.TWILIO_ACCOUNT_SID,
-    process.env.TWILIO_API_SID,
+    process.env.TWILIO_API_KEY,
     process.env.TWILIO_API_SECRET,
     { ttl: MAX_ALLOWED_SESSION_DURATION }
   );


### PR DESCRIPTION
Fixed the .env template to API_SID from API_KEY.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
