### PR TITLE
JSDK-2770-QuickstartMobileUI

### DIFF
--- a/examples/remotereconnection/public/index.css
+++ b/examples/remotereconnection/public/index.css
@@ -8,50 +8,16 @@ body {
   height: 100%;
 }
 
-/* portrait tablets, portrait iPad, landscape e-readers, landscape 800x480 or 854x480 phones
-* and smartphones, iPhone, portrait 480x320 phones */
-/* @media screen and (min-width: 768px) {
-  .collapse.dont-collapse-sm {
-    display: block;
-    height: auto !important;
-    visibility: visible;
-  }
-  [data-toggle="collapse"].collapsed .if-not-collapsed {
-    display: none;
-  }
-
-  [data-toggle="collapse"]:not(.collapsed) .if-collapsed {
-    display: none;
-  }
-} */
-/* @media screen and (max-device-width : 640px) and (orientation: portrait) {
-  .collapse.dont-collapse-sm {
-    display: block;
-    height: auto !important;
-    visibility: visible;
-  }
-
-  [data-toggle="collapse"].collapsed .if-not-collapsed {
-    display: none;
-  }
-
-  [data-toggle="collapse"]:not(.collapsed) .if-collapsed {
-    display: none;
-  }
-} */
-
-/* .collapse.dont-collapse-sm {
-  display: block;
-  height: auto !important;
-  visibility: visible;
-} */
-
 [data-toggle="collapse"].collapsed .if-not-collapsed {
   display: none;
 }
 
 [data-toggle="collapse"]:not(.collapsed) .if-collapsed {
   display: none;
+}
+
+.card {
+  border: none;
 }
 
 div.container-fluid {

--- a/examples/remotereconnection/public/index.css
+++ b/examples/remotereconnection/public/index.css
@@ -39,7 +39,7 @@ div.row.thin-gutters > [class*="col-"] {
 }
 
 div.col-sm-6, div.col-sm-6 {
-  height: 100%;
+  max-height: fit-content;
 }
 
 div.roomstate {

--- a/examples/remotereconnection/public/index.css
+++ b/examples/remotereconnection/public/index.css
@@ -8,21 +8,14 @@ body {
   height: 100%;
 }
 
-[data-toggle="collapse"].if-collapsed {
-  display: none;
-}
-
 /* portrait tablets, portrait iPad, landscape e-readers, landscape 800x480 or 854x480 phones
 * and smartphones, iPhone, portrait 480x320 phones */
-@media (min-width: 768px) {
+/* @media screen and (min-width: 768px) {
   .collapse.dont-collapse-sm {
     display: block;
     height: auto !important;
     visibility: visible;
   }
-}
-
-@media screen and (max-device-width : 640px) and (orientation: portrait) {
   [data-toggle="collapse"].collapsed .if-not-collapsed {
     display: none;
   }
@@ -30,6 +23,35 @@ body {
   [data-toggle="collapse"]:not(.collapsed) .if-collapsed {
     display: none;
   }
+} */
+/* @media screen and (max-device-width : 640px) and (orientation: portrait) {
+  .collapse.dont-collapse-sm {
+    display: block;
+    height: auto !important;
+    visibility: visible;
+  }
+
+  [data-toggle="collapse"].collapsed .if-not-collapsed {
+    display: none;
+  }
+
+  [data-toggle="collapse"]:not(.collapsed) .if-collapsed {
+    display: none;
+  }
+} */
+
+/* .collapse.dont-collapse-sm {
+  display: block;
+  height: auto !important;
+  visibility: visible;
+} */
+
+[data-toggle="collapse"].collapsed .if-not-collapsed {
+  display: none;
+}
+
+[data-toggle="collapse"]:not(.collapsed) .if-collapsed {
+  display: none;
 }
 
 div.container-fluid {

--- a/examples/remotereconnection/public/index.css
+++ b/examples/remotereconnection/public/index.css
@@ -8,37 +8,29 @@ body {
   height: 100%;
 }
 
-.show-snippet-btn {
-  display: none;
-}
-
-.hide-snippet-btn {
+[data-toggle="collapse"].if-collapsed {
   display: none;
 }
 
 /* portrait tablets, portrait iPad, landscape e-readers, landscape 800x480 or 854x480 phones
 * and smartphones, iPhone, portrait 480x320 phones */
-@media screen and (max-device-width : 640px) and (orientation: portrait) {
-  .show-snippet-btn {
-    display: grid;
-  }
-
-  .hide-snippet-btn {
-    display: grid;
-  }
-
-  .shown-snippet {
-    display: none;
-  }
-
-  .hidden {
-    display: none;
+@media (min-width: 768px) {
+  .collapse.dont-collapse-sm {
+    display: block;
+    height: auto !important;
+    visibility: visible;
   }
 }
 
-/* tablet, landscape iPad, lo-res laptops ands desktops and big landscape tablets, laptops, and desktops
-@media (min-width:961px) and (min-width:1025px) {
-} */
+@media screen and (max-device-width : 640px) and (orientation: portrait) {
+  [data-toggle="collapse"].collapsed .if-not-collapsed {
+    display: none;
+  }
+
+  [data-toggle="collapse"]:not(.collapsed) .if-collapsed {
+    display: none;
+  }
+}
 
 div.container-fluid {
   height: 100%;

--- a/examples/remotereconnection/public/index.css
+++ b/examples/remotereconnection/public/index.css
@@ -18,6 +18,7 @@ body {
 
 .card {
   border: none;
+  max-height: min-content;
 }
 
 div.container-fluid {
@@ -75,7 +76,7 @@ div#p1-media video,
 div#p2-media video {
   margin: 1em;
   max-width: 80% !important;
-  max-height: 80% !important;
+  max-height: 60% !important;
   background-color: lightgrey !important;
   background-image: url('https://static0.twilio.com/marketing/bundles/archetype/img/logo-wordmark.svg');
   background-position: 50%;

--- a/examples/remotereconnection/public/index.css
+++ b/examples/remotereconnection/public/index.css
@@ -8,6 +8,38 @@ body {
   height: 100%;
 }
 
+.show-snippet-btn {
+  display: none;
+}
+
+.hide-snippet-btn {
+  display: none;
+}
+
+/* portrait tablets, portrait iPad, landscape e-readers, landscape 800x480 or 854x480 phones
+* and smartphones, iPhone, portrait 480x320 phones */
+@media screen and (max-device-width : 640px) and (orientation: portrait) {
+  .show-snippet-btn {
+    display: grid;
+  }
+
+  .hide-snippet-btn {
+    display: grid;
+  }
+
+  .shown-snippet {
+    display: none;
+  }
+
+  .hidden {
+    display: none;
+  }
+}
+
+/* tablet, landscape iPad, lo-res laptops ands desktops and big landscape tablets, laptops, and desktops
+@media (min-width:961px) and (min-width:1025px) {
+} */
+
 div.container-fluid {
   height: 100%;
 }
@@ -50,7 +82,7 @@ div.roomstate.reconnecting.current {
   background: yellow;
 }
 
-div#p1-media, 
+div#p1-media,
 div#p2-media {
   height: 50%;
   width: 100%;

--- a/examples/remotereconnection/public/index.html
+++ b/examples/remotereconnection/public/index.html
@@ -11,27 +11,23 @@
 <body>
   <div class="container-fluid">
     <div class="row thin-gutters">
-      <div class="col-sm-6">
+      <div class="col-md-auto">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">
               Remote Participant Reconnection States
             </h4>
-            <div class="accordion" id="accordionSnippet">
-              <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
-                <span class="if-collapsed">Show Snippet</span>
-                <span class="if-not-collapsed">Hide Snippet</span>
-              </button>
-              <div class="card-body">
-                <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet" data-parent="#accordionSnippet">
-                  <pre id="shown-snippet" class="language-javascript"></pre>
-                </div>
-              </div>
+            <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
+              <span class="if-collapsed">Show Snippet</span>
+              <span class="if-not-collapsed">Hide Snippet</span>
+            </button>
+            <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
+              <pre id="shown-snippet" class="language-javascript"></pre>
             </div>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="col-sm-4">
+    <div class="col-sm-auto">
       <div class="card">
         <div class="card-block">
           <h4 class="card-title">Local View</h4>

--- a/examples/remotereconnection/public/index.html
+++ b/examples/remotereconnection/public/index.html
@@ -17,10 +17,19 @@
             <h4 class="card-title">
               Remote Participant Reconnection States
             </h4>
-            <button id="show-snippet-btn" class="btn btn-primary btn-block show-snippet-btn" >Show Code Snippet</button>
+            <!-- <button id="show-snippet-btn" class="btn btn-primary btn-block show-snippet-btn" >Show Code Snippet</button>
             <pre id="shown-snippet" class="language-javascript hidden"></pre>
-            <button id="hide-snippet-btn" class="btn btn-primary btn-block hide-snippet-btn hidden" >Hide Code Snippet</button>
+            <button id="hide-snippet-btn" class="btn btn-primary btn-block hide-snippet-btn hidden" >Hide Code Snippet</button> -->
+            <!-- yes -->
+            <button class="btn btn-primary collapsed" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
+              <span class="if-collapsed">Show Snippet</span>
+              <span class="if-not-collapsed">Hide Snippet</span>
+            </button>
+          </p>
+          <div class="collapse dont-collapse-sm" id="collapseSnippet">
+              <pre id="shown-snippet" class="language-javascript"></pre>
           </div>
+          <!--YES-->
         </div>
       </div>
     </div>
@@ -52,5 +61,8 @@
     </div>
   </div>
 <script src="index.js"></script>
+<script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/remotereconnection/public/index.html
+++ b/examples/remotereconnection/public/index.html
@@ -31,24 +31,28 @@
       <div class="card">
         <div class="card-block">
           <h4 class="card-title">Local View</h4>
-          <div id="p1-media"></div>
-          <button id="p1-simulate-reconnection" class="btn btn-primary btn-block">Simulate Reconnection</button>
-          <h5>State</h5>
-          <div id="p1">
-            <div class="roomstate connected current">Connected</div>
-            <div class="roomstate reconnecting">Reconnecting</div>
+          <div class="card-body">
+            <div id="p1-media"></div>
+            <button id="p1-simulate-reconnection" class="btn btn-primary btn-block">Simulate Reconnection</button>
+            <h5>State</h5>
+            <div id="p1">
+              <div class="roomstate connected current">Connected</div>
+              <div class="roomstate reconnecting">Reconnecting</div>
+            </div>
           </div>
         </div>
       </div>
       <div class="card">
         <div class="card-block">
           <h4 class="card-title">Remote View</h4>
-          <div id="p2-media"></div>
-          <button id="p2-simulate-reconnection" class="btn btn-primary btn-block">Simulate Reconnection</button>
-          <h5>State</h5>
-          <div id="p2">
-            <div class="roomstate connected current">Connected</div>
-            <div class="roomstate reconnecting">Reconnecting</div>
+        <div class="card-body">
+            <div id="p2-media"></div>
+            <button id="p2-simulate-reconnection" class="btn btn-primary btn-block">Simulate Reconnection</button>
+            <h5>State</h5>
+            <div id="p2">
+              <div class="roomstate connected current">Connected</div>
+              <div class="roomstate reconnecting">Reconnecting</div>
+            </div>
           </div>
         </div>
       </div>

--- a/examples/remotereconnection/public/index.html
+++ b/examples/remotereconnection/public/index.html
@@ -17,39 +17,40 @@
             <h4 class="card-title">
               Remote Participant Reconnection States
             </h4>
-            <pre class="language-javascript"></pre>
+            <button id="show-snippet-btn" class="btn btn-primary btn-block show-snippet-btn" >Show Code Snippet</button>
+            <pre id="shown-snippet" class="language-javascript"></pre>
+            <button id="hide-snippet-btn" class="btn btn-primary btn-block hide-snippet-btn" >Hide Code Snippet</button>
           </div>
         </div>
       </div>
-      <div class="col-sm-4">
-        <div class="card">
-          <div class="card-block">
-            <h4 class="card-title">Local View</h4>
-            <div id="p1-media"></div>
-            <button id="p1-simulate-reconnection" class="btn btn-primary btn-block">Simulate Reconnection</button>
-            <h5>State</h5>
-            <div id="p1">
-              <div class="roomstate connected current">Connected</div>
-              <div class="roomstate reconnecting">Reconnecting</div>
-            </div>
+    </div>
+    <div class="col-sm-4">
+      <div class="card">
+        <div class="card-block">
+          <h4 class="card-title">Local View</h4>
+          <div id="p1-media"></div>
+          <button id="p1-simulate-reconnection" class="btn btn-primary btn-block">Simulate Reconnection</button>
+          <h5>State</h5>
+          <div id="p1">
+            <div class="roomstate connected current">Connected</div>
+            <div class="roomstate reconnecting">Reconnecting</div>
           </div>
         </div>
-            <div class="card">
-              <div class="card-block">
-                <h4 class="card-title">Remote View</h4>
-                <div id="p2-media"></div>
-                <button id="p2-simulate-reconnection" class="btn btn-primary btn-block">Simulate Reconnection</button>
-                <h5>State</h5>
-                <div id="p2">
-                  <div class="roomstate connected current">Connected</div>
-                  <div class="roomstate reconnecting">Reconnecting</div>
-                </div>
-              </div>
-            </div>
+      </div>
+      <div class="card">
+        <div class="card-block">
+          <h4 class="card-title">Remote View</h4>
+          <div id="p2-media"></div>
+          <button id="p2-simulate-reconnection" class="btn btn-primary btn-block">Simulate Reconnection</button>
+          <h5>State</h5>
+          <div id="p2">
+            <div class="roomstate connected current">Connected</div>
+            <div class="roomstate reconnecting">Reconnecting</div>
+          </div>
         </div>
       </div>
     </div>
   </div>
-  <script src="index.js"></script>
+<script src="index.js"></script>
 </body>
 </html>

--- a/examples/remotereconnection/public/index.html
+++ b/examples/remotereconnection/public/index.html
@@ -18,8 +18,8 @@
               Remote Participant Reconnection States
             </h4>
             <button id="show-snippet-btn" class="btn btn-primary btn-block show-snippet-btn" >Show Code Snippet</button>
-            <pre id="shown-snippet" class="language-javascript"></pre>
-            <button id="hide-snippet-btn" class="btn btn-primary btn-block hide-snippet-btn" >Hide Code Snippet</button>
+            <pre id="shown-snippet" class="language-javascript hidden"></pre>
+            <button id="hide-snippet-btn" class="btn btn-primary btn-block hide-snippet-btn hidden" >Hide Code Snippet</button>
           </div>
         </div>
       </div>

--- a/examples/remotereconnection/public/index.html
+++ b/examples/remotereconnection/public/index.html
@@ -17,19 +17,17 @@
             <h4 class="card-title">
               Remote Participant Reconnection States
             </h4>
-            <!-- <button id="show-snippet-btn" class="btn btn-primary btn-block show-snippet-btn" >Show Code Snippet</button>
-            <pre id="shown-snippet" class="language-javascript hidden"></pre>
-            <button id="hide-snippet-btn" class="btn btn-primary btn-block hide-snippet-btn hidden" >Hide Code Snippet</button> -->
-            <!-- yes -->
-            <button class="btn btn-primary collapsed" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
-              <span class="if-collapsed">Show Snippet</span>
-              <span class="if-not-collapsed">Hide Snippet</span>
-            </button>
-          </p>
-          <div class="collapse dont-collapse-sm" id="collapseSnippet">
-              <pre id="shown-snippet" class="language-javascript"></pre>
-          </div>
-          <!--YES-->
+            <div class="accordion" id="accordionSnippet">
+              <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
+                <span class="if-collapsed">Show Snippet</span>
+                <span class="if-not-collapsed">Hide Snippet</span>
+              </button>
+              <div class="card-body">
+                <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet" data-parent="#accordionSnippet">
+                  <pre id="shown-snippet" class="language-javascript"></pre>
+                </div>
+              </div>
+            </div>
         </div>
       </div>
     </div>

--- a/examples/remotereconnection/public/index.html
+++ b/examples/remotereconnection/public/index.html
@@ -11,7 +11,7 @@
 <body>
   <div class="container-fluid">
     <div class="row thin-gutters">
-      <div class="col-md-auto">
+      <div class="col-sm-6">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">
@@ -27,7 +27,7 @@
           </div>
         </div>
       </div>
-    <div class="col-sm-auto">
+    <div class="col-sm-6">
       <div class="card">
         <div class="card-block">
           <h4 class="card-title">Local View</h4>
@@ -45,7 +45,7 @@
       <div class="card">
         <div class="card-block">
           <h4 class="card-title">Remote View</h4>
-        <div class="card-body">
+          <div class="card-body">
             <div id="p2-media"></div>
             <button id="p2-simulate-reconnection" class="btn btn-primary btn-block">Simulate Reconnection</button>
             <h5>State</h5>

--- a/examples/remotereconnection/public/index.html
+++ b/examples/remotereconnection/public/index.html
@@ -58,9 +58,9 @@
       </div>
     </div>
   </div>
-<script src="index.js"></script>
-<script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+  <script src="index.js"></script>
+  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/remotereconnection/src/index.js
+++ b/examples/remotereconnection/src/index.js
@@ -45,31 +45,31 @@ function getTracks(participant) {
 
 
   // For Mobile : Buttons and state to interact with code snippet
-  const state = {
-    snippetShown: false,
-  }
+  // const state = {
+  //   snippetShown: false,
+  // }
 
-  const updateUI = () => {
-    if(state.snippetShown) {
-      showSnippetBtn.classList.add('hidden');
-      hideSnippetBtn.classList.remove('hidden');
-      snippetEl.classList.remove('hidden');
-    } else {
-      showSnippetBtn.classList.remove('hidden');
-      hideSnippetBtn.classList.add('hidden');
-      snippetEl.classList.add('hidden');
-    }
-  }
+  // const updateUI = () => {
+  //   if(state.snippetShown) {
+  //     showSnippetBtn.classList.add('hidden');
+  //     hideSnippetBtn.classList.remove('hidden');
+  //     snippetEl.classList.remove('hidden');
+  //   } else {
+  //     showSnippetBtn.classList.remove('hidden');
+  //     hideSnippetBtn.classList.add('hidden');
+  //     snippetEl.classList.add('hidden');
+  //   }
+  // }
 
-  showSnippetBtn.addEventListener('click', () => {
-    state.snippetShown = true;
-    updateUI()
-  });
+  // showSnippetBtn.addEventListener('click', () => {
+  //   state.snippetShown = true;
+  //   updateUI()
+  // });
 
-  hideSnippetBtn.addEventListener('click', () => {
-    state.snippetShown = false;
-    updateUI();
-  });
+  // hideSnippetBtn.addEventListener('click', () => {
+  //   state.snippetShown = false;
+  //   updateUI();
+  // });
 
   // Stateless counterparts
   // showSnippetBtn.addEventListener('click', () => {

--- a/examples/remotereconnection/src/index.js
+++ b/examples/remotereconnection/src/index.js
@@ -12,9 +12,6 @@ const p1Media = document.getElementById('p1-media');
 const p2Media = document.getElementById('p2-media');
 const P1simulateReconnection = document.getElementById('p1-simulate-reconnection');
 const P2simulateReconnection = document.getElementById('p2-simulate-reconnection');
-const showSnippetBtn = document.getElementById('show-snippet-btn');
-const hideSnippetBtn = document.getElementById('hide-snippet-btn');
-const snippetEl = document.getElementById('shown-snippet');
 
 // Update UI to indicate remote side room state changes
 const onRoomStateChange = (participant, newState) => {

--- a/examples/remotereconnection/src/index.js
+++ b/examples/remotereconnection/src/index.js
@@ -12,6 +12,9 @@ const p1Media = document.getElementById('p1-media');
 const p2Media = document.getElementById('p2-media');
 const P1simulateReconnection = document.getElementById('p1-simulate-reconnection');
 const P2simulateReconnection = document.getElementById('p2-simulate-reconnection');
+const showSnippetBtn = document.getElementById('show-snippet-btn');
+const hideSnippetBtn = document.getElementById('hide-snippet-btn');
+const snippetEl = document.getElementById('shown-snippet');
 
 // Update UI to indicate remote side room state changes
 const onRoomStateChange = (participant, newState) => {
@@ -37,26 +40,71 @@ function getTracks(participant) {
   // Load the code snippet.
   const snippet = await getSnippet('./helpers.js');
   const pre = document.querySelector('pre.language-javascript');
-  
+
   pre.innerHTML = Prism.highlight(snippet, Prism.languages.javascript);
-  
+
+  const state = {
+    snippetShown: false,
+  }
+
+  const updateUI = () => {
+    console.log('state', state);
+    if(state.snippetShown) {
+      showSnippetBtn.classList.add('hidden');
+      hideSnippetBtn.classList.remove('hidden');
+      snippetEl.classList.remove('hidden');
+    } else {
+      showSnippetBtn.classList.remove('hidden');
+      hideSnippetBtn.classList.add('hidden');
+      snippetEl.classList.add('hidden');
+    }
+  }
+
+  // For Mobile : Buttons to interact with code snippet
+  showSnippetBtn.addEventListener('click', () => {
+    state.snippetShown = true;
+    updateUI()
+    // showSnippetBtn.classList.add('hidden');
+    // showSnippetBtn.classList.remove('visible');
+
+    // shownSnippet.classList.add('visible');
+    // shownSnippet.classList.remove('hidden');
+
+    // hideSnippetBtn.classList.remove('hidden');
+    // hideSnippetBtn.classList.add('visible');
+  });
+
+  hideSnippetBtn.addEventListener('click', () => {
+    state.snippetShown = false;
+    updateUI();
+
+  //   shownSnippet.classList.add('hidden');
+  //   shownSnippet.classList.remove('visible');
+
+  //   showSnippetBtn.classList.add('hidden');
+  //   showSnippetBtn.classList.remove('visible');
+
+  //   hideSnippetBtn.classList.remove('visible');
+  //   hideSnippetBtn.classList.add('hidden');
+  });
+
   // Get the credentials to connect to the Room.
   const credsP1 = await getRoomCredentials();
   const credsP2 = await getRoomCredentials();
-  
+
   // Create room instance and name for participants to join.
   const roomP1 = await Video.connect(credsP1.token, {
     region: 'au1'
   });
-  
+
   // Set room name for participant 2 to join.
   const roomName = roomP1.name;
-  
+
   // Appends video/audio tracks when LocalParticipant is connected.
   getTracks(roomP1.localParticipant).forEach(track => {
     p1Media.appendChild(track.attach());
   })
-  
+
   // Appends video/audio tracks when LocalParticipant is subscribed.
   roomP1.on('trackSubscribed', track => {
     p2Media.appendChild(track.attach());
@@ -81,12 +129,12 @@ function getTracks(participant) {
   handleRemoteParticipantReconnectionUpdates(roomP1, state => {
     onRoomStateChange('p2', state);
   });
-  
+
   handleLocalParticipantReconnectionUpdates(roomP1, state => {
     onRoomStateChange('p1', state);
   });
 
-  // Disconnect from the Room 
+  // Disconnect from the Room
   window.onbeforeunload = () => {
     roomP1.disconnect();
     roomP2.disconnect();

--- a/examples/remotereconnection/src/index.js
+++ b/examples/remotereconnection/src/index.js
@@ -43,55 +43,6 @@ function getTracks(participant) {
 
   pre.innerHTML = Prism.highlight(snippet, Prism.languages.javascript);
 
-
-  // For Mobile : Buttons and state to interact with code snippet
-  // const state = {
-  //   snippetShown: false,
-  // }
-
-  // const updateUI = () => {
-  //   if(state.snippetShown) {
-  //     showSnippetBtn.classList.add('hidden');
-  //     hideSnippetBtn.classList.remove('hidden');
-  //     snippetEl.classList.remove('hidden');
-  //   } else {
-  //     showSnippetBtn.classList.remove('hidden');
-  //     hideSnippetBtn.classList.add('hidden');
-  //     snippetEl.classList.add('hidden');
-  //   }
-  // }
-
-  // showSnippetBtn.addEventListener('click', () => {
-  //   state.snippetShown = true;
-  //   updateUI()
-  // });
-
-  // hideSnippetBtn.addEventListener('click', () => {
-  //   state.snippetShown = false;
-  //   updateUI();
-  // });
-
-  // Stateless counterparts
-  // showSnippetBtn.addEventListener('click', () => {
-  //   if(snippetEl.classList.contains('hidden')) {
-  //     showSnippetBtn.classList.add('hidden');
-  //     hideSnippetBtn.classList.remove('hidden');
-  //     snippetEl.classList.remove('hidden');
-  //   } else {
-  //     console.log('Snippet is already shown, why are u here')
-  //   }
-  // });
-
-  // hideSnippetBtn.addEventListener('click', () => {
-  //   if(!snippetEl.classList.contains('hidden')) {
-  //     showSnippetBtn.classList.remove('hidden');
-  //     hideSnippetBtn.classList.add('hidden');
-  //     snippetEl.classList.add('hidden');
-  //   } else {
-  //     console.log('Snippet is hidden already')
-  //   }
-  // })
-
   // Get the credentials to connect to the Room.
   const credsP1 = await getRoomCredentials();
   const credsP2 = await getRoomCredentials();

--- a/examples/remotereconnection/src/index.js
+++ b/examples/remotereconnection/src/index.js
@@ -43,12 +43,13 @@ function getTracks(participant) {
 
   pre.innerHTML = Prism.highlight(snippet, Prism.languages.javascript);
 
+
+  // For Mobile : Buttons and state to interact with code snippet
   const state = {
     snippetShown: false,
   }
 
   const updateUI = () => {
-    console.log('state', state);
     if(state.snippetShown) {
       showSnippetBtn.classList.add('hidden');
       hideSnippetBtn.classList.remove('hidden');
@@ -60,33 +61,36 @@ function getTracks(participant) {
     }
   }
 
-  // For Mobile : Buttons to interact with code snippet
   showSnippetBtn.addEventListener('click', () => {
     state.snippetShown = true;
     updateUI()
-    // showSnippetBtn.classList.add('hidden');
-    // showSnippetBtn.classList.remove('visible');
-
-    // shownSnippet.classList.add('visible');
-    // shownSnippet.classList.remove('hidden');
-
-    // hideSnippetBtn.classList.remove('hidden');
-    // hideSnippetBtn.classList.add('visible');
   });
 
   hideSnippetBtn.addEventListener('click', () => {
     state.snippetShown = false;
     updateUI();
-
-  //   shownSnippet.classList.add('hidden');
-  //   shownSnippet.classList.remove('visible');
-
-  //   showSnippetBtn.classList.add('hidden');
-  //   showSnippetBtn.classList.remove('visible');
-
-  //   hideSnippetBtn.classList.remove('visible');
-  //   hideSnippetBtn.classList.add('hidden');
   });
+
+  // Stateless counterparts
+  // showSnippetBtn.addEventListener('click', () => {
+  //   if(snippetEl.classList.contains('hidden')) {
+  //     showSnippetBtn.classList.add('hidden');
+  //     hideSnippetBtn.classList.remove('hidden');
+  //     snippetEl.classList.remove('hidden');
+  //   } else {
+  //     console.log('Snippet is already shown, why are u here')
+  //   }
+  // });
+
+  // hideSnippetBtn.addEventListener('click', () => {
+  //   if(!snippetEl.classList.contains('hidden')) {
+  //     showSnippetBtn.classList.remove('hidden');
+  //     hideSnippetBtn.classList.add('hidden');
+  //     snippetEl.classList.add('hidden');
+  //   } else {
+  //     console.log('Snippet is hidden already')
+  //   }
+  // })
 
   // Get the credentials to connect to the Room.
   const credsP1 = await getRoomCredentials();


### PR DESCRIPTION
Redesigning the UI on remote reconnection example. The UI has been made more friendly for different devices including tablets on landscape/portrait mode. I will apply similar styling in other examples in another PR.

On Chrome:
![quickstartUI](https://user-images.githubusercontent.com/43423318/81112441-7fb47d00-8ed3-11ea-8d71-5a84a3d49f62.gif)

On Safari:
![quickstartUISAFARI](https://user-images.githubusercontent.com/43423318/81112723-f5204d80-8ed3-11ea-8a07-876b8a84e14f.gif)

on iOS Safari:
![Image from iOS](https://user-images.githubusercontent.com/43423318/81113178-a7581500-8ed4-11ea-834c-1e59d84b39d0.png)
![Image from iOS (1)](https://user-images.githubusercontent.com/43423318/81113184-a921d880-8ed4-11ea-834b-622ad9e77a54.png)


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
