### PR TITLE
JSDK-2770 Mobile Friendly Quickstart Examples

### DIFF
--- a/examples/bandwidthconstraints/public/index.css
+++ b/examples/bandwidthconstraints/public/index.css
@@ -8,6 +8,18 @@ body {
   height: 100%;
 }
 
+[data-toggle="collapse"].collapsed .if-not-collapsed {
+  display: none;
+}
+
+[data-toggle="collapse"]:not(.collapsed) .if-collapsed {
+  display: none;
+}
+
+.align {
+  align-content: flex-start;
+}
+
 div.container-fluid {
   height: 100%;
 }
@@ -25,8 +37,8 @@ div.row.thin-gutters > [class*="col-"] {
   padding: 0 2px;
 }
 
-div.col-sm-8, div.col-sm-4 {
-  height: 100%;
+div.col-sm-6, div.col-sm-6 {
+  height: fit-content;
 }
 
 pre.language-javascript {
@@ -50,18 +62,6 @@ div.card {
 
 div.input-group > select {
   width: 100%;
-}
-
-div.col-sm-8 > .card {
-  height: 100%;
-}
-
-div.col-sm-4 > .card:first-child {
-  height: 30%;
-}
-
-div.col-sm-4 > .card:last-child {
-  height: 70%;
 }
 
 div#audiowaveform {

--- a/examples/bandwidthconstraints/public/index.css
+++ b/examples/bandwidthconstraints/public/index.css
@@ -66,8 +66,6 @@ div.input-group > select {
 
 div#audiowaveform {
   position: absolute;
-  left: 20px;
-  top: 58px;
   width: 20%;
   height: 20%;
   background-color: darkgrey !important;

--- a/examples/bandwidthconstraints/public/index.css
+++ b/examples/bandwidthconstraints/public/index.css
@@ -34,7 +34,7 @@ div.row.thin-gutters {
 
 div.row.thin-gutters > .col,
 div.row.thin-gutters > [class*="col-"] {
-  padding: 0 2px;
+  padding: 8px 8px;
 }
 
 div.col-sm-6, div.col-sm-6 {

--- a/examples/bandwidthconstraints/public/index.html
+++ b/examples/bandwidthconstraints/public/index.html
@@ -18,8 +18,8 @@
               Bandwidth Constraints
             </h4>
             <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
-              <span class="if-collapsed">Show Snippet</span>
-              <span class="if-not-collapsed">Hide Snippet</span>
+              <span class="if-collapsed">Show Code</span>
+              <span class="if-not-collapsed">Hide Code</span>
             </button>
             <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
               <pre id="shown-snippet" class="language-javascript"></pre>

--- a/examples/bandwidthconstraints/public/index.html
+++ b/examples/bandwidthconstraints/public/index.html
@@ -4,24 +4,30 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Bandwidth Constraints</title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <link rel="stylesheet" href="prism.css">
   <link rel="stylesheet" href="index.css">
 </head>
 <body>
   <div class="container-fluid">
-    <div class="row thin-gutters">
-      <div class="col-sm-8">
+    <div class="row thin-gutters align">
+      <div class="col-sm-6">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">
               Bandwidth Constraints
             </h4>
-            <pre class="language-javascript"></pre>
+            <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
+              <span class="if-collapsed">Show Snippet</span>
+              <span class="if-not-collapsed">Hide Snippet</span>
+            </button>
+            <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
+              <pre id="shown-snippet" class="language-javascript"></pre>
+            </div>
           </div>
         </div>
       </div>
-      <div class="col-sm-4">
+      <div class="col-sm-6">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">Participant's Media</h4>
@@ -67,5 +73,8 @@
     </div>
   </div>
   <script src="index.js"></script>
+  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/bandwidthconstraints/public/index.html
+++ b/examples/bandwidthconstraints/public/index.html
@@ -33,7 +33,7 @@
             <h4 class="card-title">Participant's Media</h4>
             <div id="audiowaveform"></div>
             <audio id="audiopreview" autoplay></audio>
-            <video id="videopreview" autoplay align="center"></video>
+            <video id="videopreview" autoplay></video>
           </div>
         </div>
         <div class="card">

--- a/examples/codecpreferences/public/index.css
+++ b/examples/codecpreferences/public/index.css
@@ -8,6 +8,18 @@ body {
   height: 100%;
 }
 
+[data-toggle="collapse"].collapsed .if-not-collapsed {
+  display: none;
+}
+
+[data-toggle="collapse"]:not(.collapsed) .if-collapsed {
+  display: none;
+}
+
+.align {
+  align-content: flex-start;
+}
+
 div.container-fluid {
   height: 100%;
 }
@@ -25,8 +37,8 @@ div.row.thin-gutters > [class*="col-"] {
   padding: 0 2px;
 }
 
-div.col-sm-8, div.col-sm-4 {
-  height: 100%;
+div.col-sm-6, div.col-sm-6 {
+  max-height: fit-content;
 }
 
 pre.language-javascript {
@@ -50,18 +62,6 @@ div.card {
 
 div.input-group > select {
   width: 100%;
-}
-
-div.col-sm-8 > .card {
-  height: 100%;
-}
-
-div.col-sm-4 > .card:first-child {
-  height: 30%;
-}
-
-div.col-sm-4 > .card:last-child {
-  height: 70%;
 }
 
 div#audiowaveform {

--- a/examples/codecpreferences/public/index.css
+++ b/examples/codecpreferences/public/index.css
@@ -34,7 +34,7 @@ div.row.thin-gutters {
 
 div.row.thin-gutters > .col,
 div.row.thin-gutters > [class*="col-"] {
-  padding: 0 2px;
+  padding: 8px 8px;
 }
 
 div.col-sm-6, div.col-sm-6 {

--- a/examples/codecpreferences/public/index.html
+++ b/examples/codecpreferences/public/index.html
@@ -18,8 +18,8 @@
               Codec Preferences
             </h4>
             <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
-              <span class="if-collapsed">Show Snippet</span>
-              <span class="if-not-collapsed">Hide Snippet</span>
+              <span class="if-collapsed">Show Code</span>
+              <span class="if-not-collapsed">Hide Code</span>
             </button>
             <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
               <pre id="shown-snippet" class="language-javascript"></pre>

--- a/examples/codecpreferences/public/index.html
+++ b/examples/codecpreferences/public/index.html
@@ -4,24 +4,30 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Codec Preferences</title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <link rel="stylesheet" href="prism.css">
   <link rel="stylesheet" href="index.css">
 </head>
 <body>
   <div class="container-fluid">
-    <div class="row thin-gutters">
-      <div class="col-sm-8">
+    <div class="row thin-gutters align">
+      <div class="col-sm-6">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">
               Codec Preferences
             </h4>
-            <pre class="language-javascript"></pre>
+            <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
+              <span class="if-collapsed">Show Snippet</span>
+              <span class="if-not-collapsed">Hide Snippet</span>
+            </button>
+            <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
+              <pre id="shown-snippet" class="language-javascript"></pre>
+            </div>
           </div>
         </div>
       </div>
-      <div class="col-sm-4">
+      <div class="col-sm-6">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">Participant's Media</h4>
@@ -69,5 +75,8 @@
     </div>
   </div>
   <script src="index.js"></script>
+  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/codecpreferences/public/index.html
+++ b/examples/codecpreferences/public/index.html
@@ -33,7 +33,7 @@
             <h4 class="card-title">Participant's Media</h4>
             <div id="audiowaveform"></div>
             <audio id="audiopreview" autoplay></audio>
-            <video id="videopreview" autoplay align="center"></video>
+            <video id="videopreview" autoplay></video>
           </div>
         </div>
         <div class="card">

--- a/examples/dominantspeaker/public/index.css
+++ b/examples/dominantspeaker/public/index.css
@@ -127,18 +127,9 @@ div.input-group > select {
   width: 100%;
 }
 
-div.col-sm-8 > .card {
-  height: 100%;
+div.col-sm-6, div.col-sm-6 {
+  max-height: fit-content;
 }
-
-div.col-sm-4 > .card:first-child {
-  height: 30%;
-}
-
-div.col-sm-4 > .card:last-child {
-  height: 70%;
-}
-
 
 @media (max-width: 900px) {
   div.col-sm-8, div.col-sm-4 {

--- a/examples/dominantspeaker/public/index.css
+++ b/examples/dominantspeaker/public/index.css
@@ -8,6 +8,18 @@ body {
   height: 100%;
 }
 
+[data-toggle="collapse"].collapsed .if-not-collapsed {
+  display: none;
+}
+
+[data-toggle="collapse"]:not(.collapsed) .if-collapsed {
+  display: none;
+}
+
+.align {
+  align-content: flex-start;
+}
+
 div.container-fluid {
   height: 100%;
 }
@@ -26,7 +38,7 @@ div.row.thin-gutters > [class*="col-"] {
 }
 
 div.col-sm-6, div.col-sm-6 {
-  height: 100%;
+  max-height: fit-content;
 }
 
 div#remote-media {

--- a/examples/dominantspeaker/public/index.css
+++ b/examples/dominantspeaker/public/index.css
@@ -34,7 +34,7 @@ div.row.thin-gutters {
 
 div.row.thin-gutters > .col,
 div.row.thin-gutters > [class*="col-"] {
-  padding: 0 2px;
+  padding: 8px 8px;
 }
 
 div.col-sm-6, div.col-sm-6 {

--- a/examples/dominantspeaker/public/index.html
+++ b/examples/dominantspeaker/public/index.html
@@ -18,8 +18,8 @@
               Dominant Speaker Detection
             </h4>
             <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
-              <span class="if-collapsed">Show Snippet</span>
-              <span class="if-not-collapsed">Hide Snippet</span>
+              <span class="if-collapsed">Show Code</span>
+              <span class="if-not-collapsed">Hide Code</span>
             </button>
             <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
               <pre id="shown-snippet" class="language-javascript"></pre>

--- a/examples/dominantspeaker/public/index.html
+++ b/examples/dominantspeaker/public/index.html
@@ -4,20 +4,26 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Dominant Speaker</title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <link rel="stylesheet" href="prism.css">
   <link rel="stylesheet" href="index.css">
 </head>
 <body>
   <div class="container-fluid">
-    <div class="row thin-gutters">
+    <div class="row thin-gutters align">
       <div class="col-sm-6">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">
               Dominant Speaker Detection
             </h4>
-            <pre class="language-javascript"></pre>
+            <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
+              <span class="if-collapsed">Show Snippet</span>
+              <span class="if-not-collapsed">Hide Snippet</span>
+            </button>
+            <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
+              <pre id="shown-snippet" class="language-javascript"></pre>
+            </div>
           </div>
         </div>
       </div>
@@ -35,5 +41,8 @@
     </div>
   </div>
   <script src="index.js"></script>
+  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/localmediacontrols/public/index.css
+++ b/examples/localmediacontrols/public/index.css
@@ -76,20 +76,24 @@ div#userControls > button {
 }
 
 div#media-container {
-  position: relative;
+  display: grid;
+  grid-template-areas: 'content';
+  width: 100%
+}
+
+div#videopreview {
+  grid-area: content;
+  width: 100%;
 }
 
 div#audiopreview {
-  position: absolute;
-  top: 0;
-  right: 0;
-  height: auto;
-  width: 100%;
+  grid-area: content;
+  z-index: 1;
   background-color: transparent;
-  text-align: center;
-  margin: auto;
   padding: 2px 2px;
+  width: 100%;
 }
+
 
 div#audiopreview > span > i#activeIcon {
  display: flex;
@@ -98,14 +102,6 @@ div#audiopreview > span > i#activeIcon {
 
 div#audiopreview > span > i#inactiveIcon {
   display:none;
-}
-
-div#videopreview {
-  height: 75%;
-  width: 75%;
-  background-color: #fff;
-  margin: auto;
-  width: 100%;
 }
 
 div#videopreview > video {

--- a/examples/localmediacontrols/public/index.css
+++ b/examples/localmediacontrols/public/index.css
@@ -8,6 +8,18 @@ body {
   height: 100%;
 }
 
+[data-toggle="collapse"].collapsed .if-not-collapsed {
+  display: none;
+}
+
+[data-toggle="collapse"]:not(.collapsed) .if-collapsed {
+  display: none;
+}
+
+.align {
+  align-content: flex-start;
+}
+
 div.container-fluid {
   height: 100%;
 }
@@ -30,8 +42,8 @@ div.card {
   overflow-y: auto;
 }
 
-div.col-sm-8 > .card {
-  height: 100%;
+div.col-sm-6, div.col-sm-6 {
+  max-height: fit-content;
 }
 
 
@@ -60,7 +72,7 @@ div#userControls > button {
   align-items: center;
   margin:5px;
   border-radius: 8px;
-  transition-duration: 0.4s; 
+  transition-duration: 0.4s;
 }
 
 div#audiopreview {

--- a/examples/localmediacontrols/public/index.css
+++ b/examples/localmediacontrols/public/index.css
@@ -75,15 +75,20 @@ div#userControls > button {
   transition-duration: 0.4s;
 }
 
+div#media-container {
+  position: relative;
+}
+
 div#audiopreview {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
+  position: absolute;
+  top: 0;
+  right: 0;
   height: auto;
   width: 100%;
-  background-color: #fff;
+  background-color: transparent;
   text-align: center;
   margin: auto;
+  padding: 2px 2px;
 }
 
 div#audiopreview > span > i#activeIcon {
@@ -96,9 +101,6 @@ div#audiopreview > span > i#inactiveIcon {
 }
 
 div#videopreview {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
   height: 75%;
   width: 75%;
   background-color: #fff;

--- a/examples/localmediacontrols/public/index.css
+++ b/examples/localmediacontrols/public/index.css
@@ -34,7 +34,7 @@ div.row.thin-gutters {
 
 div.row.thin-gutters > .col,
 div.row.thin-gutters > [class*="col-"] {
-  padding: 0 2px;
+  padding: 8px 8px;
 }
 
 div.card {

--- a/examples/localmediacontrols/public/index.html
+++ b/examples/localmediacontrols/public/index.html
@@ -19,8 +19,8 @@
               Enabling and Disabling Tracks
             </h4>
             <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
-              <span class="if-collapsed">Show Snippet</span>
-              <span class="if-not-collapsed">Hide Snippet</span>
+              <span class="if-collapsed">Show Code</span>
+              <span class="if-not-collapsed">Hide Code</span>
             </button>
             <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
               <pre id="shown-snippet" class="language-javascript"></pre>

--- a/examples/localmediacontrols/public/index.html
+++ b/examples/localmediacontrols/public/index.html
@@ -11,18 +11,24 @@
 </head>
 <body>
   <div class="container-fluid">
-    <div class="row thin-gutters">
+    <div class="row thin-gutters align">
       <div class="col-sm-6">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">
               Enabling and Disabling Tracks
             </h4>
-            <pre class="language-javascript"></pre>
+            <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
+              <span class="if-collapsed">Show Snippet</span>
+              <span class="if-not-collapsed">Hide Snippet</span>
+            </button>
+            <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
+              <pre id="shown-snippet" class="language-javascript"></pre>
+            </div>
           </div>
         </div>
       </div>
-      <div class="col-sm-4">
+      <div class="col-sm-6">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">Local Media Controls</h4>
@@ -52,5 +58,8 @@
     </div>
   </div>
   <script src="index.js"></script>
+  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/localmediacontrols/public/index.html
+++ b/examples/localmediacontrols/public/index.html
@@ -33,8 +33,8 @@
           <div class="card-block">
             <h4 class="card-title">Local Media Controls</h4>
             <div id="userControls">
-              <button id="muteAudioBtn" class="btn btn-primary btn-block" >Mute Audio</button>
-              <button id="muteVideoBtn" class="btn btn-primary btn-block" >Stop Video</button>
+              <button id="muteAudioBtn" class="btn btn-primary btn-block" >Disable Audio</button>
+              <button id="muteVideoBtn" class="btn btn-primary btn-block" >Disable Video</button>
             </div>
           </div>
         </div>

--- a/examples/localmediacontrols/public/index.html
+++ b/examples/localmediacontrols/public/index.html
@@ -41,15 +41,17 @@
             <div class="card">
               <div class="card-block">
                 <h4 class="card-title">RemoteParticipant View</h4>
-                <div id="audiopreview">
-                  <span>
-                    <i id="activeIcon" class="fas fa-volume-up"></i>
-                  </span>
-                  <span>
-                    <i id="inactiveIcon" class="fas fa-volume-mute"></i>
-                  </span>
-                </div>
-                <div id="videopreview">
+                <div id="media-container">
+                  <div id="videopreview">
+                  </div>
+                  <div id="audiopreview">
+                    <span>
+                      <i id="activeIcon" class="fas fa-volume-up"></i>
+                    </span>
+                    <span>
+                      <i id="inactiveIcon" class="fas fa-volume-mute"></i>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/examples/localmediacontrols/src/index.js
+++ b/examples/localmediacontrols/src/index.js
@@ -19,7 +19,7 @@ let roomName = null;
   // Load the code snippet.
   const snippet = await getSnippet('./helpers.js');
   const pre = document.querySelector('pre.language-javascript');
-  
+
   pre.innerHTML = Prism.highlight(snippet, Prism.languages.javascript);
 
   // Get the credentials to connect to the Room.
@@ -47,30 +47,30 @@ let roomName = null;
     if(mute) {
       muteYourAudio(roomP1);
       muteAudioBtn.classList.add('muted');
-      muteAudioBtn.innerText = 'Unmute Audio';
+      muteAudioBtn.innerText = 'Enable Audio';
       activeIcon.id = 'inactiveIcon';
       inactiveIcon.id = 'activeIcon';
 
     } else {
       unmuteYourAudio(roomP1);
       muteAudioBtn.classList.remove('muted');
-      muteAudioBtn.innerText = 'Mute Audio';
+      muteAudioBtn.innerText = 'Disable Audio';
       activeIcon.id = 'inactiveIcon';
       inactiveIcon.id = 'activeIcon';
     }
   }
-  
+
   muteVideoBtn.onclick = () => {
     const mute = !muteVideoBtn.classList.contains('muted');
-    
+
     if(mute) {
       muteYourVideo(roomP1);
       muteVideoBtn.classList.add('muted');
-      muteVideoBtn.innerText = 'Start Video';
+      muteVideoBtn.innerText = 'Enable Video';
     } else {
       unmuteYourVideo(roomP1);
       muteVideoBtn.classList.remove('muted');
-      muteVideoBtn.innerText = 'Stop Video';
+      muteVideoBtn.innerText = 'Disable Video';
     }
   }
 
@@ -98,7 +98,7 @@ let roomName = null;
       });
   }));
 
-  // Disconnect from the Room 
+  // Disconnect from the Room
   window.onbeforeunload = () => {
     roomP1.disconnect();
     roomP2.disconnect();

--- a/examples/localmediacontrols/src/index.js
+++ b/examples/localmediacontrols/src/index.js
@@ -75,7 +75,7 @@ let roomName = null;
   }
 
   // Starts video upon P2 joining room
-  roomP2.on('trackSubscribed', (track => {
+  roomP2.on('trackSubscribed', track => {
     if (track.isEnabled) {
       if (track.kind === 'audio') {
         audioPreview.appendChild(track.attach());
@@ -83,20 +83,20 @@ let roomName = null;
         videoPreview.appendChild(track.attach());
       }
     }
+  });
 
-    participantMutedOrUnmutedMedia(roomP2, track => {
-      track.detach().forEach(element => {
-        element.remove();
-      });
-    }, track => {
-        if (track.kind === 'audio') {
-          audioPreview.appendChild(track.attach());
-        }
-        if (track.kind === 'video') {
-          videoPreview.appendChild(track.attach());
-        }
-      });
-  }));
+  participantMutedOrUnmutedMedia(roomP2, track => {
+    track.detach().forEach(element => {
+      element.remove();
+    });
+  }, track => {
+      if (track.kind === 'audio') {
+        audioPreview.appendChild(track.attach());
+      }
+      if (track.kind === 'video') {
+        videoPreview.appendChild(track.attach());
+      }
+  });
 
   // Disconnect from the Room
   window.onbeforeunload = () => {

--- a/examples/localvideofilter/public/index.css
+++ b/examples/localvideofilter/public/index.css
@@ -8,6 +8,18 @@ body {
   height: 100%;
 }
 
+[data-toggle="collapse"].collapsed .if-not-collapsed {
+  display: none;
+}
+
+[data-toggle="collapse"]:not(.collapsed) .if-collapsed {
+  display: none;
+}
+
+.align {
+  align-content: flex-start;
+}
+
 div.container-fluid {
   height: 100%;
 }
@@ -48,12 +60,8 @@ div.card {
   overflow-y: auto;
 }
 
-div.col-sm-8 > .card {
-  height: 100%;
-}
-
-div.col-sm-4 > .card {
-  height: 50%;
+div.col-sm-6, div.col-sm-6 {
+  max-height: fit-content;
 }
 
 video#videoinputfiltered,

--- a/examples/localvideofilter/public/index.css
+++ b/examples/localvideofilter/public/index.css
@@ -34,7 +34,7 @@ div.row.thin-gutters {
 
 div.row.thin-gutters > .col,
 div.row.thin-gutters > [class*="col-"] {
-  padding: 0 2px;
+  padding: 8px 8px;
 }
 
 div.col-sm-8, div.col-sm-4 {

--- a/examples/localvideofilter/public/index.html
+++ b/examples/localvideofilter/public/index.html
@@ -19,8 +19,8 @@
               Local Video Filter
             </h4>
             <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
-              <span class="if-collapsed">Show Snippet</span>
-              <span class="if-not-collapsed">Hide Snippet</span>
+              <span class="if-collapsed">Show Code</span>
+              <span class="if-not-collapsed">Hide Code</span>
             </button>
             <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
               <pre id="shown-snippet" class="language-javascript"></pre>

--- a/examples/localvideofilter/public/index.html
+++ b/examples/localvideofilter/public/index.html
@@ -5,24 +5,30 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Local Video Filter</title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <link rel="stylesheet" href="prism.css">
   <link rel="stylesheet" href="index.css">
 </head>
 <body>
   <div class="container-fluid">
-    <div class="row thin-gutters">
-      <div class="col-sm-8">
+    <div class="row thin-gutters align">
+      <div class="col-sm-6">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">
               Local Video Filter
             </h4>
-            <pre class="language-javascript"></pre>
+            <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
+              <span class="if-collapsed">Show Snippet</span>
+              <span class="if-not-collapsed">Hide Snippet</span>
+            </button>
+            <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
+              <pre id="shown-snippet" class="language-javascript"></pre>
+            </div>
           </div>
         </div>
       </div>
-      <div class="col-sm-4">
+      <div class="col-sm-6">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">Local Video (raw)</h4>
@@ -45,5 +51,8 @@
     </div>
   </div>
   <script src="index.js"></script>
+  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/localvideosnapshot/public/index.css
+++ b/examples/localvideosnapshot/public/index.css
@@ -8,6 +8,18 @@ body {
   height: 100%;
 }
 
+[data-toggle="collapse"].collapsed .if-not-collapsed {
+  display: none;
+}
+
+[data-toggle="collapse"]:not(.collapsed) .if-collapsed {
+  display: none;
+}
+
+.align {
+  align-content: flex-start;
+}
+
 div.container-fluid {
   height: 100%;
 }
@@ -23,6 +35,10 @@ div.row.thin-gutters {
 div.row.thin-gutters > .col,
 div.row.thin-gutters > [class*="col-"] {
   padding: 0 2px;
+}
+
+div.col-sm-6, div.col-sm-6 {
+  max-height: fit-content;
 }
 
 div.col-sm-8, div.col-sm-4 {
@@ -46,14 +62,6 @@ pre.language-javascript a:hover {
 div.card {
   border: none;
   overflow-y: auto;
-}
-
-div.col-sm-8 > .card {
-  height: 100%;
-}
-
-div.col-sm-4 > .card {
-  height: 50%;
 }
 
 canvas#snapshot,

--- a/examples/localvideosnapshot/public/index.css
+++ b/examples/localvideosnapshot/public/index.css
@@ -34,7 +34,7 @@ div.row.thin-gutters {
 
 div.row.thin-gutters > .col,
 div.row.thin-gutters > [class*="col-"] {
-  padding: 0 2px;
+  padding: 8px 8px;
 }
 
 div.col-sm-6, div.col-sm-6 {

--- a/examples/localvideosnapshot/public/index.html
+++ b/examples/localvideosnapshot/public/index.html
@@ -19,8 +19,8 @@
               Local Video Snapshot
             </h4>
             <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
-              <span class="if-collapsed">Show Snippet</span>
-              <span class="if-not-collapsed">Hide Snippet</span>
+              <span class="if-collapsed">Show Code</span>
+              <span class="if-not-collapsed">Hide Code</span>
             </button>
             <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
               <pre id="shown-snippet" class="language-javascript"></pre>

--- a/examples/localvideosnapshot/public/index.html
+++ b/examples/localvideosnapshot/public/index.html
@@ -5,24 +5,30 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Local Video Snapshot</title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <link rel="stylesheet" href="prism.css">
   <link rel="stylesheet" href="index.css">
 </head>
 <body>
   <div class="container-fluid">
-    <div class="row thin-gutters">
-      <div class="col-sm-8">
+    <div class="row thin-gutters align">
+      <div class="col-sm-6">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">
               Local Video Snapshot
             </h4>
-            <pre class="language-javascript"></pre>
+            <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
+              <span class="if-collapsed">Show Snippet</span>
+              <span class="if-not-collapsed">Hide Snippet</span>
+            </button>
+            <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
+              <pre id="shown-snippet" class="language-javascript"></pre>
+            </div>
           </div>
         </div>
       </div>
-      <div class="col-sm-4">
+      <div class="col-sm-6">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">Local Video</h4>
@@ -40,5 +46,8 @@
     </div>
   </div>
   <script src="index.js"></script>
+  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/mediadevices/public/index.css
+++ b/examples/mediadevices/public/index.css
@@ -76,10 +76,6 @@ span.input-group-btn > button.btn.btn-primary.btn-sm {
   border-radius: 0;
 }
 
-/* div.col-sm-8 > .card {
-  height: 100%;
-} */
-
 div#audioinputwaveform {
   position: absolute;
   left: 20px;

--- a/examples/mediadevices/public/index.css
+++ b/examples/mediadevices/public/index.css
@@ -8,6 +8,23 @@ body {
   height: 100%;
 }
 
+[data-toggle="collapse"].collapsed .if-not-collapsed {
+  display: none;
+}
+
+[data-toggle="collapse"]:not(.collapsed) .if-collapsed {
+  display: none;
+}
+
+.card {
+  border: none;
+  max-height: min-content;
+}
+
+.align {
+  align-content: flex-start;
+}
+
 div.container-fluid {
   height: 100%;
 }
@@ -32,8 +49,8 @@ div.row.thin-gutters > [class*="col-"] {
   padding: 0 2px;
 }
 
-div.col-sm-8, div.col-sm-4 {
-  height: 100%;
+div.col-sm-6, div.col-sm-6 {
+  height: fit-content;
 }
 
 pre.language-javascript {
@@ -50,11 +67,6 @@ pre.language-javascript a:hover {
   text-decoration: none;
 }
 
-div.card {
-  border: none;
-  overflow-y: auto;
-}
-
 div.input-group > select {
   width: 100%;
 }
@@ -64,9 +76,9 @@ span.input-group-btn > button.btn.btn-primary.btn-sm {
   border-radius: 0;
 }
 
-div.col-sm-8 > .card {
+/* div.col-sm-8 > .card {
   height: 100%;
-}
+} */
 
 div#audioinputwaveform {
   position: absolute;

--- a/examples/mediadevices/public/index.css
+++ b/examples/mediadevices/public/index.css
@@ -46,7 +46,7 @@ div#remote-media video {
 
 div.row.thin-gutters > .col,
 div.row.thin-gutters > [class*="col-"] {
-  padding: 0 2px;
+  padding: 8px 8px;
 }
 
 div.col-sm-6, div.col-sm-6 {

--- a/examples/mediadevices/public/index.html
+++ b/examples/mediadevices/public/index.html
@@ -19,8 +19,8 @@
               Media Device Selection
             </h4>
             <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
-              <span class="if-collapsed">Show Snippet</span>
-              <span class="if-not-collapsed">Hide Snippet</span>
+              <span class="if-collapsed">Show Code</span>
+              <span class="if-not-collapsed">Hide Code</span>
             </button>
             <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
               <pre id="shown-snippet" class="language-javascript"></pre>

--- a/examples/mediadevices/public/index.html
+++ b/examples/mediadevices/public/index.html
@@ -5,20 +5,26 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Media Device Selection</title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <link rel="stylesheet" href="prism.css">
   <link rel="stylesheet" href="index.css">
 </head>
 <body>
   <div class="container-fluid">
-    <div class="row thin-gutters">
+    <div class="row thin-gutters align">
       <div class="col-sm-6">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">
               Media Device Selection
             </h4>
-            <pre class="language-javascript"></pre>
+            <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
+              <span class="if-collapsed">Show Snippet</span>
+              <span class="if-not-collapsed">Hide Snippet</span>
+            </button>
+            <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
+              <pre id="shown-snippet" class="language-javascript"></pre>
+            </div>
           </div>
         </div>
       </div>
@@ -78,5 +84,8 @@
     </div>
   </div>
   <script src="index.js"></script>
+  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/networkquality/public/index.css
+++ b/examples/networkquality/public/index.css
@@ -8,6 +8,23 @@ body {
   height: 100%;
 }
 
+[data-toggle="collapse"].collapsed .if-not-collapsed {
+  display: none;
+}
+
+[data-toggle="collapse"]:not(.collapsed) .if-collapsed {
+  display: none;
+}
+
+.card {
+  border: none;
+  max-height: min-content;
+}
+
+.align {
+  align-content: flex-start;
+}
+
 div.container-fluid {
   height: 100%;
 }
@@ -26,11 +43,11 @@ div.row.thin-gutters > [class*="col-"] {
 }
 
 div.col-sm-6, div.col-sm-6 {
-  height: 100%;
+  height: fit-content;
 }
 
 div#remotemedia {
-  display: flex;
+  display: grid;
   justify-content: flex-start;
   flex-wrap: wrap;
   height: auto;
@@ -74,7 +91,7 @@ div#remotemedia textarea {
 }
 
 div#usercontrols {
-  display: flex;
+  display: grid;
   flex-direction: column;
   flex-wrap: wrap;
   width: 100%;
@@ -105,27 +122,9 @@ pre.language-javascript a:hover {
   text-decoration: none;
 }
 
-div.card {
-  border: none;
-  overflow-y: auto;
-}
-
 div.input-group > select {
   width: 100%;
 }
-
-div.col-sm-8 > .card {
-  height: 100%;
-}
-
-div.col-sm-4 > .card:first-child {
-  height: 30%;
-}
-
-div.col-sm-4 > .card:last-child {
-  height: 70%;
-}
-
 
 @media (max-width: 900px) {
   div.col-sm-8, div.col-sm-4 {

--- a/examples/networkquality/public/index.css
+++ b/examples/networkquality/public/index.css
@@ -39,7 +39,7 @@ div.row.thin-gutters {
 
 div.row.thin-gutters > .col,
 div.row.thin-gutters > [class*="col-"] {
-  padding: 0 2px;
+  padding: 8px 8px;
 }
 
 div.col-sm-6, div.col-sm-6 {

--- a/examples/networkquality/public/index.html
+++ b/examples/networkquality/public/index.html
@@ -18,8 +18,8 @@
               Network Quality
             </h4>
             <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
-              <span class="if-collapsed">Show Snippet</span>
-              <span class="if-not-collapsed">Hide Snippet</span>
+              <span class="if-collapsed">Show Code</span>
+              <span class="if-not-collapsed">Hide Code</span>
             </button>
             <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
               <pre id="shown-snippet" class="language-javascript"></pre>

--- a/examples/networkquality/public/index.html
+++ b/examples/networkquality/public/index.html
@@ -4,20 +4,26 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Network Quality</title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <link rel="stylesheet" href="prism.css">
   <link rel="stylesheet" href="index.css">
 </head>
 <body>
   <div class="container-fluid">
-    <div class="row thin-gutters">
+    <div class="row thin-gutters align">
       <div class="col-sm-6">
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">
               Network Quality
             </h4>
-            <pre class="language-javascript"></pre>
+            <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
+              <span class="if-collapsed">Show Snippet</span>
+              <span class="if-not-collapsed">Hide Snippet</span>
+            </button>
+            <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
+              <pre id="shown-snippet" class="language-javascript"></pre>
+            </div>
           </div>
         </div>
       </div>
@@ -25,30 +31,32 @@
         <div class="card">
           <div class="card-block">
             <h4 class="card-title">Set Network Quality Verbosity Levels</h4>
-            <form>
-              <div class="form-group">
-                <label class="form-text text-muted">LocalParticipant</label>
-                <div class="input-group">
-                  <select id="local" name="local">
-                    <option value="1" selected>1</option>
-                    <option value="2">2</option>
-                    <option value="3">3</option>
-                  </select>
+            <div class="card-body">
+              <form>
+                <div class="form-group">
+                  <label class="form-text text-muted">LocalParticipant</label>
+                  <div class="input-group">
+                    <select id="local" name="local">
+                      <option value="1" selected>1</option>
+                      <option value="2">2</option>
+                      <option value="3">3</option>
+                    </select>
+                  </div>
                 </div>
-              </div>
-              <div class="form-group">
-                <label class="form-text text-muted">RemoteParticipant(s)</label>
-                <div class="input-group">
-                  <select id="remote" name="remote">
-                    <option value="0" selected>0</option>
-                    <option value="1">1</option>
-                    <option value="2">2</option>
-                    <option value="3">3</option>
-                  </select>
+                <div class="form-group">
+                  <label class="form-text text-muted">RemoteParticipant(s)</label>
+                  <div class="input-group">
+                    <select id="remote" name="remote">
+                      <option value="0" selected>0</option>
+                      <option value="1">1</option>
+                      <option value="2">2</option>
+                      <option value="3">3</option>
+                    </select>
+                  </div>
                 </div>
-              </div>
-              <input id="setuproom" class="btn btn-primary btn-block" type="submit" value="Create Room">
-            </form>
+                <input id="setuproom" class="btn btn-primary btn-block" type="submit" value="Create Room">
+              </form>
+            </div>
           </div>
         </div>
         <div id="joinroom" class="card-block" style="display:none">
@@ -66,5 +74,8 @@
     </div>
   </div>
   <script src="index.js"></script>
+  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/reconnection/public/index.css
+++ b/examples/reconnection/public/index.css
@@ -8,6 +8,14 @@ body {
   height: 100%;
 }
 
+[data-toggle="collapse"].collapsed .if-not-collapsed {
+  display: none;
+}
+
+[data-toggle="collapse"]:not(.collapsed) .if-collapsed {
+  display: none;
+}
+
 div.container-fluid {
   height: 100%;
 }
@@ -26,7 +34,7 @@ div.row.thin-gutters > [class*="col-"] {
 }
 
 div.col-sm-6, div.col-sm-6 {
-  height: 100%;
+  max-height: fit-content;
 }
 
 div#remote-media {

--- a/examples/reconnection/public/index.css
+++ b/examples/reconnection/public/index.css
@@ -16,6 +16,10 @@ body {
   display: none;
 }
 
+.align {
+  align-content: flex-start;
+}
+
 div.container-fluid {
   height: 100%;
 }

--- a/examples/reconnection/public/index.css
+++ b/examples/reconnection/public/index.css
@@ -105,19 +105,6 @@ div.input-group > select {
   width: 100%;
 }
 
-div.col-sm-8 > .card {
-  height: 100%;
-}
-
-div.col-sm-4 > .card:first-child {
-  height: 30%;
-}
-
-div.col-sm-4 > .card:last-child {
-  height: 70%;
-}
-
-
 @media (max-width: 900px) {
   div.col-sm-8, div.col-sm-4 {
     max-width: 100%;

--- a/examples/reconnection/public/index.css
+++ b/examples/reconnection/public/index.css
@@ -34,7 +34,7 @@ div.row.thin-gutters {
 
 div.row.thin-gutters > .col,
 div.row.thin-gutters > [class*="col-"] {
-  padding: 0 2px;
+  padding: 8px 8px;
 }
 
 div.col-sm-6, div.col-sm-6 {

--- a/examples/reconnection/public/index.html
+++ b/examples/reconnection/public/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div class="container-fluid">
-    <div class="row thin-gutters">
+    <div class="row thin-gutters align">
       <div class="col-sm-6">
         <div class="card">
           <div class="card-block">

--- a/examples/reconnection/public/index.html
+++ b/examples/reconnection/public/index.html
@@ -18,8 +18,8 @@
               Reconnection States and Events
             </h4>
             <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
-              <span class="if-collapsed">Show Snippet</span>
-              <span class="if-not-collapsed">Hide Snippet</span>
+              <span class="if-collapsed">Show Code</span>
+              <span class="if-not-collapsed">Hide Code</span>
             </button>
             <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
               <pre id="shown-snippet" class="language-javascript"></pre>

--- a/examples/reconnection/public/index.html
+++ b/examples/reconnection/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Reconnection States and Events</title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <link rel="stylesheet" href="prism.css">
   <link rel="stylesheet" href="index.css">
 </head>
@@ -17,31 +17,42 @@
             <h4 class="card-title">
               Reconnection States and Events
             </h4>
-            <pre class="language-javascript"></pre>
+            <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
+              <span class="if-collapsed">Show Snippet</span>
+              <span class="if-not-collapsed">Hide Snippet</span>
+            </button>
+            <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
+              <pre id="shown-snippet" class="language-javascript"></pre>
+            </div>
           </div>
         </div>
       </div>
       <div class="col-sm-6">
         <div class="card-block">
-            <h5> Room state is: </h5>
-            <div class="roomstate connected">Connected</div>
-            <div class="roomstate disconnected current">Disconnected</div>
-            <div class="roomstate reconnecting">Reconnecting</div>
-            <input id="createRoom" type="submit" class="btn btn-primary btn-block" value="Create Room">
-            <p>
-              After you have created the Room, please either turn off your internet network for a little while
-              and then turn it back on, or switch between networks. The Twilio Video SDK will try to re-establish
-              connection to the Room, which will transition to the "connecting" state. Once reconnection is complete,
-              the Room will transition back to the "connected" state.
+            <h4 class="card-title"> Room state is: </h4>
+            <div class="card-body">
+              <div class="roomstate connected">Connected</div>
+              <div class="roomstate disconnected current">Disconnected</div>
+              <div class="roomstate reconnecting">Reconnecting</div>
+              <input id="createRoom" type="submit" class="btn btn-primary btn-block" value="Create Room">
+              <p>
+                After you have created the Room, please either turn off your internet network for a little while
+                and then turn it back on, or switch between networks. The Twilio Video SDK will try to re-establish
+                connection to the Room, which will transition to the "connecting" state. Once reconnection is complete,
+                the Room will transition back to the "connected" state.
 
-              You can join other user to the room using button below.
-            </p>
-            <input id="connectordisconnect" type="submit" class="btn btn-primary btn-block" value="Join Room">
+                You can join other user to the room using button below.
+              </p>
+              <input id="connectordisconnect" type="submit" class="btn btn-primary btn-block" value="Join Room">
+            </div>
         </div>
         <div id="remote-media"></div>
       </div>
     </div>
   </div>
   <script src="index.js"></script>
+  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/remotereconnection/public/index.css
+++ b/examples/remotereconnection/public/index.css
@@ -39,7 +39,7 @@ div.row.thin-gutters {
 
 div.row.thin-gutters > .col,
 div.row.thin-gutters > [class*="col-"] {
-  padding: 0 2px;
+  padding: 8px 8px;
 }
 
 div.col-sm-6, div.col-sm-6 {

--- a/examples/remotereconnection/public/index.css
+++ b/examples/remotereconnection/public/index.css
@@ -21,6 +21,10 @@ body {
   max-height: min-content;
 }
 
+.align {
+  align-content: flex-start;
+}
+
 div.container-fluid {
   height: 100%;
 }

--- a/examples/remotereconnection/public/index.html
+++ b/examples/remotereconnection/public/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div class="container-fluid">
-    <div class="row thin-gutters">
+    <div class="row thin-gutters align">
       <div class="col-sm-6">
         <div class="card">
           <div class="card-block">

--- a/examples/remotereconnection/public/index.html
+++ b/examples/remotereconnection/public/index.html
@@ -18,8 +18,8 @@
               Remote Participant Reconnection States
             </h4>
             <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
-              <span class="if-collapsed">Show Snippet</span>
-              <span class="if-not-collapsed">Hide Snippet</span>
+              <span class="if-collapsed">Show Code</span>
+              <span class="if-not-collapsed">Hide Code</span>
             </button>
             <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
               <pre id="shown-snippet" class="language-javascript"></pre>

--- a/examples/remotereconnection/src/index.js
+++ b/examples/remotereconnection/src/index.js
@@ -44,9 +44,13 @@ function getTracks(participant) {
   const credsP1 = await getRoomCredentials();
   const credsP2 = await getRoomCredentials();
 
+    // Create Local Tracks
+    const localTracks = await Video.createLocalTracks();
+
   // Create room instance and name for participants to join.
   const roomP1 = await Video.connect(credsP1.token, {
-    region: 'au1'
+    region: 'au1',
+    tracks: localTracks,
   });
 
   // Set room name for participant 2 to join.
@@ -55,7 +59,7 @@ function getTracks(participant) {
   // Appends video/audio tracks when LocalParticipant is connected.
   getTracks(roomP1.localParticipant).forEach(track => {
     p1Media.appendChild(track.attach());
-  })
+  });
 
   // Appends video/audio tracks when LocalParticipant is subscribed.
   roomP1.on('trackSubscribed', track => {
@@ -65,7 +69,8 @@ function getTracks(participant) {
   // Connecting remote participants.
   const roomP2 = await Video.connect(credsP2.token, {
     name: roomName,
-    region: 'au1'
+    region: 'au1',
+    tracks: localTracks
   });
 
   // Simulate reconnection button functionalities, adding in region in order to extend reconnection time

--- a/examples/screenshare/public/index.css
+++ b/examples/screenshare/public/index.css
@@ -8,6 +8,25 @@ body {
   height: 100%;
 }
 
+[data-toggle="collapse"].collapsed .if-not-collapsed {
+  display: none;
+}
+
+[data-toggle="collapse"]:not(.collapsed) .if-collapsed {
+  display: none;
+}
+
+.card {
+  border: none;
+  max-height: fit-content;
+  overflow-y: auto;
+}
+
+.card-body {
+  width: 640px;
+  max-width: fit-content;
+}
+
 div.container-fluid {
   height: 100%;
 }
@@ -29,6 +48,10 @@ div.col-sm-8, div.col-sm-4 {
   height: 100%;
 }
 
+div.col-sm-6, div.col-sm-6 {
+  max-height: fit-content;
+}
+
 pre.language-javascript {
   font-family: 'Roboto Mono', monospace;
   font-size: 13px;
@@ -43,28 +66,18 @@ pre.language-javascript a:hover {
   text-decoration: none;
 }
 
-div.card {
-  border: none;
-  overflow-y: auto;
-}
-
-div.col-sm-8 > .card {
-  height: 100%;
-}
-
-div.col-sm-4 > .card:first-child {
-  height: 30%;
-}
-
-div.col-sm-4 > .card:last-child {
-  height: 70%;
-}
-
 video#screenpreview {
+  margin: auto;
   background-color: lightgrey !important;
   background-image: url('https://static0.twilio.com/marketing/bundles/archetype/img/logo-wordmark.svg');
   background-position: 50%;
   background-repeat: no-repeat;
+  min-width: 100%;
+  max-width: 100%;
+}
+
+.screenshare > .btn-block {
+  width:640px
 }
 
 @media (max-width: 900px) {

--- a/examples/screenshare/public/index.css
+++ b/examples/screenshare/public/index.css
@@ -45,7 +45,7 @@ div.row.thin-gutters {
 
 div.row.thin-gutters > .col,
 div.row.thin-gutters > [class*="col-"] {
-  padding: 0 2px;
+  padding: 8px 8px;
 }
 
 div.col-sm-8, div.col-sm-4 {

--- a/examples/screenshare/public/index.css
+++ b/examples/screenshare/public/index.css
@@ -22,6 +22,10 @@ body {
   overflow-y: auto;
 }
 
+.align {
+  align-content: flex-start;
+}
+
 .card-body {
   width: 640px;
   max-width: fit-content;

--- a/examples/screenshare/public/index.html
+++ b/examples/screenshare/public/index.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <div class="container-fluid">
-  <div class="row thin-gutters">
+  <div class="row thin-gutters align">
     <div class="col-sm-6">
       <div class="card">
         <div class="card-block">

--- a/examples/screenshare/public/index.html
+++ b/examples/screenshare/public/index.html
@@ -19,8 +19,8 @@
             Share Your Screen
           </h4>
           <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
-            <span class="if-collapsed">Show Snippet</span>
-            <span class="if-not-collapsed">Hide Snippet</span>
+            <span class="if-collapsed">Show Code</span>
+            <span class="if-not-collapsed">Hide Code</span>
           </button>
           <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
             <pre id="shown-snippet" class="language-javascript"></pre>

--- a/examples/screenshare/public/index.html
+++ b/examples/screenshare/public/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Share Your Screen</title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <link rel="stylesheet" href="prism.css">
   <link rel="stylesheet" href="index.css">
 </head>
@@ -18,7 +18,13 @@
           <h4 class="card-title">
             Share Your Screen
           </h4>
-          <pre class="language-javascript"></pre>
+          <button class="btn btn-primary collapsed d-md-none" type="button" data-toggle="collapse" data-target="#collapseSnippet" aria-expanded="false" aria-controls="collapseSnippet">
+            <span class="if-collapsed">Show Snippet</span>
+            <span class="if-not-collapsed">Hide Snippet</span>
+          </button>
+          <div class="collapse dont-collapse-sm d-md-block" id="collapseSnippet">
+            <pre id="shown-snippet" class="language-javascript"></pre>
+          </div>
         </div>
       </div>
     </div>
@@ -26,14 +32,19 @@
       <div class="card">
         <div class="card-block">
           <h4 class="card-title">Local Screen</h4>
-          <video id="screenpreview" autoplay height="480" width="640"></video>
-          <button id="capturescreen" class="btn btn-primary btn-block">Capture Screen</button>
-          <button id="stopscreencapture" class="btn btn-primary btn-block">Stop Screen Capture</button>
+          <div id="screenshare" class="card-body">
+            <video id="screenpreview" autoplay></video>
+            <button id="capturescreen" class="btn btn-primary btn-block">Capture Screen</button>
+            <button id="stopscreencapture" class="btn btn-primary btn-block">Stop Screen Capture</button>
+          </div>
         </div>
       </div>
     </div>
   </div>
 </div>
 <script src="index.js"></script>
+<script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
[JIRA Ticket](https://issues.corp.twilio.com/browse/JSDK-2770)

BUG FIX : Remote Reconnection LocalParticipant is not showing video on mobile.

Mobile Friendly Examples UI. This is WIP but I will update as I finish styling!
- [x] Bandwidth Constraints
- [x] Local Video Filter
- [x] Local Video Snapshot
- [x] Media Device Selection
- [x] Codec Preferences
- [x] Share Your Screen
Gif of Screenshare example on Chrome
![quickstartUISS](https://user-images.githubusercontent.com/43423318/81354060-84b62f80-907f-11ea-947a-dc8275586bfb.gif)
- [x] Dominant Speaker
- [x] Reconnection States and Events 
![quickstartUIRECONNC](https://user-images.githubusercontent.com/43423318/81357150-be8b3400-9087-11ea-8b45-a1aa6a1db810.gif)

- [x] Network Quality
- [x] Enabling and Disabling Tracks
- [x] Remote Reconnection States and Events - Done in another PR and is now merged

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
