### PR TITLE
JSDK-2894 Media Devices Fix

### DIFF
--- a/examples/mediadevices/src/helpers.js
+++ b/examples/mediadevices/src/helpers.js
@@ -51,19 +51,27 @@ function applyAudioOutputDeviceSelection(deviceId, audio) {
  * @param {Room} [room] - The Room, if you have already joined one
  * @returns {Promise<void>}
  */
-function applyAudioInputDeviceSelection(deviceId, audio, room) {
-  return Video.createLocalAudioTrack({
-    deviceId: {
-      exact: deviceId // NOTE: on ios safari - it respects the deviceId only if its exact.
-    }
-  }).then(function(localTrack) {
-    localTrack.attach(audio);
-    if (room) {
-      switchLocalTracks(room, localTrack);
-    }
-  }).catch(function(error) {
-    console.log('applyAudioInputDeviceSelection failed:', error);
-  });
+// function applyAudioInputDeviceSelection(deviceId, audio, room) {
+//   return Video.createLocalAudioTrack({
+//     deviceId: {
+//       exact: deviceId // NOTE: on ios safari - it respects the deviceId only if its exact.
+//     }
+//   }).then(function(localTrack) {
+//     localTrack.attach(audio);
+//     if (room) {
+//       switchLocalTracks(room, localTrack);
+//     }
+//   }).catch(function(error) {
+//     console.log('applyAudioInputDeviceSelection failed:', error);
+//   });
+// }
+
+function applyAudioInputDeviceSelection(localAudioTrack, audio, room) {
+  localAudioTrack.attach(audio);
+  if (room) {
+    switchLocalTracks(room, localTrack);
+  }
+  return;
 }
 
 /**

--- a/examples/mediadevices/src/helpers.js
+++ b/examples/mediadevices/src/helpers.js
@@ -51,21 +51,6 @@ function applyAudioOutputDeviceSelection(deviceId, audio) {
  * @param {Room} [room] - The Room, if you have already joined one
  * @returns {Promise<void>}
  */
-// function applyAudioInputDeviceSelection(deviceId, audio, room) {
-//   return Video.createLocalAudioTrack({
-//     deviceId: {
-//       exact: deviceId // NOTE: on ios safari - it respects the deviceId only if its exact.
-//     }
-//   }).then(function(localTrack) {
-//     localTrack.attach(audio);
-//     if (room) {
-//       switchLocalTracks(room, localTrack);
-//     }
-//   }).catch(function(error) {
-//     console.log('applyAudioInputDeviceSelection failed:', error);
-//   });
-// }
-
 function applyAudioInputDeviceSelection(localAudioTrack, audio, room) {
   localAudioTrack.attach(audio);
   if (room) {

--- a/examples/mediadevices/src/helpers.js
+++ b/examples/mediadevices/src/helpers.js
@@ -72,6 +72,7 @@ function applyVideoInputDeviceSelection(deviceId, video, room) {
       publication.unpublish();
     });
   }
+  // Create the new LocalVideoTrack and publish it to the Room.
   return Video.createLocalVideoTrack({
     deviceId: {
       exact: deviceId

--- a/examples/mediadevices/src/helpers.js
+++ b/examples/mediadevices/src/helpers.js
@@ -16,23 +16,6 @@ function getDevicesOfKind(deviceInfos, kind) {
 }
 
 /**
- * Replace the existing LocalAudioTrack or LocalVideoTrack with
- * a new one in the Room.
- * @param {Room} room - The Room you have joined
- * @param {LocalAudioTrack|LocalVideoTrack} track - The LocalTrack you want to switch to
- * @returns {void}
- */
-function switchLocalTracks(room, track) {
-  room.localParticipant.tracks.forEach(function(trackPublication) {
-    if (trackPublication.kind === track.kind) {
-      trackPublication.track.stop();
-      room.localParticipant.unpublishTrack(trackPublication.track);
-    }
-  });
-  room.localParticipant.publishTrack(track);
-}
-
-/**
  * Apply the selected audio output device.
  * @param {string} deviceId
  * @param {HTMLAudioElement} audio
@@ -51,12 +34,27 @@ function applyAudioOutputDeviceSelection(deviceId, audio) {
  * @param {Room} [room] - The Room, if you have already joined one
  * @returns {Promise<void>}
  */
-function applyAudioInputDeviceSelection(localAudioTrack, audio, room) {
-  localAudioTrack.attach(audio);
+function applyAudioInputDeviceSelection(deviceId, audio, room) {
+  // Stop and unpublish the existing LocalAudioTrack.
   if (room) {
-    switchLocalTracks(room, localAudioTrack);
+    room.localParticipant.audioTracks.forEach(function(publication) {
+      publication.track.stop();
+      publication.unpublish();
+    });
   }
-  return;
+  // Create the new LocalAudioTrack and publish it to the Room.
+  return Video.createLocalAudioTrack({
+    deviceId: {
+      exact: deviceId // NOTE: on ios safari - it respects the deviceId only if its exact.
+    }
+  }).then(function(localTrack) {
+    localTrack.attach(audio);
+    if (room) {
+      return room.localParticipant.publishTrack(localTrack);
+    }
+  }).catch(function(error) {
+    console.log('applyAudioInputDeviceSelection failed:', error);
+  });
 }
 
 /**
@@ -67,6 +65,13 @@ function applyAudioInputDeviceSelection(localAudioTrack, audio, room) {
  * @returns {Promise<void>}
  */
 function applyVideoInputDeviceSelection(deviceId, video, room) {
+  // Stop and unpublish the existing LocalVideoTrack.
+  if (room) {
+    room.localParticipant.videoTracks.forEach(function(publication) {
+      publication.track.stop();
+      publication.unpublish();
+    });
+  }
   return Video.createLocalVideoTrack({
     deviceId: {
       exact: deviceId
@@ -74,7 +79,7 @@ function applyVideoInputDeviceSelection(deviceId, video, room) {
   }).then(function(localTrack) {
     localTrack.attach(video);
     if (room) {
-      switchLocalTracks(room, localTrack);
+      return room.localParticipant.publishTrack(localTrack);
     }
   }).catch(function(error) {
     console.log('applyVideoInputDeviceSelection failed:', error);

--- a/examples/mediadevices/src/helpers.js
+++ b/examples/mediadevices/src/helpers.js
@@ -69,7 +69,7 @@ function applyAudioOutputDeviceSelection(deviceId, audio) {
 function applyAudioInputDeviceSelection(localAudioTrack, audio, room) {
   localAudioTrack.attach(audio);
   if (room) {
-    switchLocalTracks(room, localTrack);
+    switchLocalTracks(room, localAudioTrack);
   }
   return;
 }

--- a/examples/mediadevices/src/index.js
+++ b/examples/mediadevices/src/index.js
@@ -140,17 +140,18 @@ async function applyAudioInputDeviceChange(event) {
     });
     audioTrack.stop();
 
-    someRoom.localParticipant.audioTracks.forEach(publication => {
-      publication.unpublish();
-    });
-
     await stopPromise;
   }
+
 
   audioTrack =  await createLocalAudioTrack({
     deviceId: {
       exact: deviceId // NOTE: on ios safari - it respects the deviceId only if its exact.
     }
+  });
+
+  someRoom.localParticipant.audioTracks.forEach(publication => {
+    publication.unpublish();
   });
 
   applyAudioInputDeviceSelection(audioTrack, audio, someRoom);
@@ -205,7 +206,6 @@ async function connectOrDisconnectRoom(event) {
     someRoom.localParticipant.audioTracks.forEach(publication => {
       audioTrack = publication.track;
     });
-    console.log('audiotrack in connect', audioTrack);
 
     // sync the preview with connected tracks.
     applyVideoInputDeviceChange();

--- a/examples/mediadevices/src/index.js
+++ b/examples/mediadevices/src/index.js
@@ -123,13 +123,12 @@ function participantDisconnected(participant) {
 async function applyAudioInputDeviceChange(event) {
   var audio = document.querySelector('audio#audioinputpreview');
   var waveformContainer = document.querySelector('div#audioinputwaveform');
-  var deviceId = deviceSelections.audioinput.value;
   if (event) {
     event.preventDefault();
     event.stopPropagation();
   }
 
-  await applyAudioInputDeviceSelection(deviceId, audio, someRoom);
+  await applyAudioInputDeviceSelection(deviceSelections.audioinput.value, audio, someRoom);
 
   if (audio.srcObject) {
     var canvas = waveformContainer.querySelector('canvas');

--- a/examples/mediadevices/src/index.js
+++ b/examples/mediadevices/src/index.js
@@ -141,12 +141,7 @@ async function applyAudioInputDeviceChange(event) {
     audioTrack.stop();
 
     someRoom.localParticipant.audioTracks.forEach(publication => {
-      console.log('PUBLICATIONTRACK', publication.track)
-      console.log('AUDIOTRACK', audioTrack)
-      if(publication.track === audioTrack) {
-        console.log('yolo swag')
-        publication.unpublish();
-      }
+      publication.unpublish();
     });
 
     await stopPromise;
@@ -158,44 +153,15 @@ async function applyAudioInputDeviceChange(event) {
     }
   });
 
-  // applyAudioInputDeviceSelection()
+  applyAudioInputDeviceSelection(audioTrack, audio, someRoom);
 
-  // someRoom.localParticipant.audioTracks.forEach(publication => {
-  //   if(!publication.track.isStopped) {
-  //     publication.track.stop();
-  //   }
-  //   console.log('publication.track.isStopped', publication.track.isStopped)
-
-  //   publication.track.on('stopped', () => {
-  //     const newAudioTrack =  createLocalAudioTrack({
-  //       deviceId: {
-  //         exact: deviceId // NOTE: on ios safari - it respects the deviceId only if its exact.
-  //       }
-  //     })
-
-  //     applyAudioInputDeviceSelection(newAudioTrack, audio, someRoom);
-  //   })
-
-  //   console.log('some element', audio.srcObject)
-  //   if (audio.srcObject) {
-  //     var canvas = waveformContainer.querySelector('canvas');
-  //     waveform.setStream(audio.srcObject);
-  //     if (!canvas) {
-  //       waveformContainer.appendChild(waveform.element);
-  //     }
-  //   }
-  // });
-
-  // return applyAudioInputDeviceSelection(deviceSelections.audioinput.value, audio, someRoom).then(function() {
-  //   if (audio.srcObject) {
-  //     console.log('then audio src object', audio.srcObject);
-  //     var canvas = waveformContainer.querySelector('canvas');
-  //     waveform.setStream(audio.srcObject);
-  //     if (!canvas) {
-  //       waveformContainer.appendChild(waveform.element);
-  //     }
-  //   }
-  // });
+  if (audio.srcObject) {
+    var canvas = waveformContainer.querySelector('canvas');
+    waveform.setStream(audio.srcObject);
+    if (!canvas) {
+      waveformContainer.appendChild(waveform.element);
+    }
+  }
 }
 
 // reads selected video input, and updates preview and room to use the device.
@@ -236,6 +202,10 @@ async function connectOrDisconnectRoom(event) {
 
     const creds = await getRoomCredentials();
     someRoom = await connectWithSelectedDevices(creds.token, deviceSelections.audioinput.value, deviceSelections.videoinput.value);
+    someRoom.localParticipant.audioTracks.forEach(publication => {
+      audioTrack = publication.track;
+    });
+    console.log('audiotrack in connect', audioTrack);
 
     // sync the preview with connected tracks.
     applyVideoInputDeviceChange();


### PR DESCRIPTION
This is the fix for Media Devices example having errors in FireFox. I have moved some logic around to keep track of the audio track being created in the main application rather in the helper function. 

[Issue Link](https://github.com/twilio/video-quickstart-js/issues/139)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
