### PR TITLE
JSDK-2867- Error Handling in Quickstart changes

### DIFF
--- a/quickstart/src/selectroom.js
+++ b/quickstart/src/selectroom.js
@@ -28,7 +28,9 @@ function selectRoom($modal, error) {
   }
 
   if (error) {
-    $alert.html(`<h6><b>${error.name}</b></h6>${getUserFriendlyError(error)}`);
+    $alert.html(`<h5>${error.name}${error.message
+      ? `: ${error.message}`
+      : ''}</h5>${getUserFriendlyError(error)}`);
     $alert.css('display', '');
   } else {
     $alert.css('display', 'none');

--- a/quickstart/src/selectroom.js
+++ b/quickstart/src/selectroom.js
@@ -28,7 +28,7 @@ function selectRoom($modal, error) {
   }
 
   if (error) {
-    $alert.html(getUserFriendlyError(error));
+    $alert.html(`<h6><b>${error.name}</b></h6>${getUserFriendlyError(error)}`);
     $alert.css('display', '');
   } else {
     $alert.css('display', 'none');

--- a/quickstart/src/selectroom.js
+++ b/quickstart/src/selectroom.js
@@ -28,7 +28,7 @@ function selectRoom($modal, error) {
   }
 
   if (error) {
-    $alert.text(getUserFriendlyError(error));
+    $alert.html(getUserFriendlyError(error));
     $alert.css('display', '');
   } else {
     $alert.css('display', 'none');

--- a/quickstart/src/showerror.js
+++ b/quickstart/src/showerror.js
@@ -16,6 +16,8 @@ function showError($modal, error) {
     keyboard: false,
     show: true
   });
+
+  $('#show-error-label').html(`${error}`);
 }
 
 module.exports = showError;

--- a/quickstart/src/showerror.js
+++ b/quickstart/src/showerror.js
@@ -17,7 +17,9 @@ function showError($modal, error) {
     show: true
   });
 
-  $('#show-error-label').html(`${error}`);
+  $('#show-error-label', $modal).text(`${error.name}${error.message
+    ? `: ${error.message}`
+    : ''}`);
 }
 
 module.exports = showError;

--- a/quickstart/src/userfriendlyerror.js
+++ b/quickstart/src/userfriendlyerror.js
@@ -2,23 +2,26 @@
 
 const USER_FRIENDLY_ERRORS = {
   NotAllowedError: () => {
-    return 'The user did not give permission to access to your input device by clicking the "deny" button on the permission dialog, or dismissing the permission dialog, or by going to the browser settings. Please allow the app to access the input device on the browser settings and reload the app.';
+    return '<b>Cause: </b><br>The user did not give permission to access to your input device by clicking the "deny" button on the permission dialog, or dismissing the permission dialog, or by going to the browser settings.<br>'
+    +'<br><b>Solution: </b><br> Please allow the app to access the input device on the browser settings and reload the app.';
   },
   NotFoundError: () => {
-    return 'The user has disabled the input device for the browser in the system settings or the user\'s machine does not have such input device connected to it. The user should enable the input device for the browser in the system settings, or have atleast one input device connected.';
+    return '<b>Cause: </b><br>The user has disabled the input device for the browser in the system settings or the user\'s machine does not have such input device connected to it.<br>'
+    +'<br><b>Solution</b><br>The user should enable the input device for the browser in the system settings, or have atleast one input device connected.';
   },
   NotReadableError: () => {
-    return 'The browser could not start media capture with the input device. Please close other apps and windows that have reserved the input device and reload the app or restart the browser.';
+    return '<b>Cause: </b><br>The browser could not start media capture with the input device.<br>'
+    +'<b>Solution: </b><br>Please close other apps and windows that have reserved the input device and reload the app or restart the browser.';
   },
   OverconstrainedError: error => {
     return error.constraint === 'deviceId'
-      ? 'Your saved microphone or camera is no longer available.'
+      ? '<b>Cause: </b>Your saved microphone or camera is no longer available.<br><b>Solution: </b><br>Please make sure the input device is connected to the machine.'
       : 'Could not satisfy the requested media constraints. One of the reasons '
         + 'could be that your saved microphone or camera is no longer available.';
   },
   TypeError: () => {
-    return '<code>navigator.mediaDevices</code> does not exist. If you\'re'
-     + ' sure that your browser supports it, make sure your app is being served from a secure context, '
+    return '<b>Cause: </b><br><code>navigator.mediaDevices</code> does not exist.<br>'
+     + '<br><b>Solution: </b><br>If you\'re sure that your browser supports it, make sure your app is being served from a secure context, '
      + 'either <code>localhost</code> or an <code>https</code> domain.';
   }
 };

--- a/quickstart/src/userfriendlyerror.js
+++ b/quickstart/src/userfriendlyerror.js
@@ -2,27 +2,28 @@
 
 const USER_FRIENDLY_ERRORS = {
   NotAllowedError: () => {
-    return '<b>Cause: </b><br>The user did not give permission to access to your input device by clicking the "deny" button on the permission dialog, or dismissing the permission dialog, or by going to the browser settings.<br>'
-    +'<br><b>Solution: </b><br> Please allow the app to access the input device on the browser settings and reload the app.';
+    return '<b>Causes: </b><br>1. The user has denied permission for your app to access the input device either by dismissing the permission dialog or clicking on the "deny" button.<br> 2. The user has denied permission for your app to access the input device in the browser settings.<br>'
+    +'<br><b>Solutions: </b><br> 1. The user should reload your app and grant permission to access the input device.<br> 2. The user should allow access to the input device in the browser settings and then reload your app.';
   },
   NotFoundError: () => {
-    return '<b>Cause: </b><br>The user has disabled the input device for the browser in the system settings or the user\'s machine does not have such input device connected to it.<br>'
-    +'<br><b>Solution</b><br>The user should enable the input device for the browser in the system settings, or have atleast one input device connected.';
+    return '<b>Cause: </b><br>1. The user has disabled the input device for the browser in the system settings.<br>2. The user\'s machine does not have such input device connected to it.<br>'
+    +'<br><b>Solution</b><br>1. The user should enable the input device for the browser in the system settings<br>2. The user should have atleast one input device connected.';
   },
   NotReadableError: () => {
-    return '<b>Cause: </b><br>The browser could not start media capture with the input device.<br>'
-    +'<br><b>Solution: </b><br>Please close other apps and windows that have reserved the input device and reload the app or restart the browser.';
+    return '<b>Cause: </b><br>The browser could not start media capture with the input device even after the user gave permission, probably because another app or tab has reserved the input device.<br>'
+    +'<br><b>Solution: </b><br>The user should close all other apps and tabs that have reserved the input device and reload your app, or worst case, restart the browser.';
   },
   OverconstrainedError: error => {
     return error.constraint === 'deviceId'
-      ? '<b>Cause: </b>Your saved microphone or camera is no longer available.<br><br><b>Solution: </b><br>Please make sure the input device is connected to the machine.'
-      : 'Could not satisfy the requested media constraints. One of the reasons '
-        + 'could be that your saved microphone or camera is no longer available.';
+      ? '<b>Cause: </b><br>Your saved microphone or camera is no longer available.<br><br><b>Solution: </b><br>Please make sure the input device is connected to the machine.'
+      : '<b>Cause: </b><br>Could not satisfy the requested media constraints. One of the reasons '
+        + 'could be that your saved microphone or camera is no longer available.<br><br><b>Solution: </b><br>Please make sure the input device is connected to the machine.';
   },
   TypeError: () => {
     return '<b>Cause: </b><br><code>navigator.mediaDevices</code> does not exist.<br>'
-     + '<br><b>Solution: </b><br>If you\'re sure that your browser supports it, make sure your app is being served from a secure context, '
-     + 'either <code>localhost</code> or an <code>https</code> domain.';
+    + '<br><b>Solution: </b><br>If you\'re sure that the browser supports '
+    + '<code>navigator.mediaDevices</code>, make sure your app is being served '
+    + 'from a secure context (<code>localhost</code> or an <code>https</code> domain).';
   }
 };
 

--- a/quickstart/src/userfriendlyerror.js
+++ b/quickstart/src/userfriendlyerror.js
@@ -11,11 +11,11 @@ const USER_FRIENDLY_ERRORS = {
   },
   NotReadableError: () => {
     return '<b>Cause: </b><br>The browser could not start media capture with the input device.<br>'
-    +'<b>Solution: </b><br>Please close other apps and windows that have reserved the input device and reload the app or restart the browser.';
+    +'<br><b>Solution: </b><br>Please close other apps and windows that have reserved the input device and reload the app or restart the browser.';
   },
   OverconstrainedError: error => {
     return error.constraint === 'deviceId'
-      ? '<b>Cause: </b>Your saved microphone or camera is no longer available.<br><b>Solution: </b><br>Please make sure the input device is connected to the machine.'
+      ? '<b>Cause: </b>Your saved microphone or camera is no longer available.<br><br><b>Solution: </b><br>Please make sure the input device is connected to the machine.'
       : 'Could not satisfy the requested media constraints. One of the reasons '
         + 'could be that your saved microphone or camera is no longer available.';
   },

--- a/quickstart/src/userfriendlyerror.js
+++ b/quickstart/src/userfriendlyerror.js
@@ -2,13 +2,13 @@
 
 const USER_FRIENDLY_ERRORS = {
   NotAllowedError: () => {
-    return 'The user did not give permission to access your media.';
+    return 'The user did not give permission to access to your input device by clicking the "deny" button on the permission dialog, or dismissing the permission dialog, or by going to the browser settings. Please allow the app to access the input device on the browser settings and reload the app.';
   },
   NotFoundError: () => {
-    return 'None of the available media types satisfied the given constraints.';
+    return 'The user has disabled the input device for the browser in the system settings or the user\'s machine does not have such input device connected to it. The user should enable the input device for the browser in the system settings, or have atleast one input device connected.';
   },
   NotReadableError: () => {
-    return 'Could not access your media due to a hardware error.';
+    return 'The browser could not start media capture with the input device. Please close other apps and windows that have reserved the input device and reload the app or restart the browser.';
   },
   OverconstrainedError: error => {
     return error.constraint === 'deviceId'
@@ -18,8 +18,8 @@ const USER_FRIENDLY_ERRORS = {
   },
   TypeError: () => {
     return '<code>navigator.mediaDevices</code> does not exist. If you\'re'
-     + ' sure that your browser supports it, make sure your app is being served'
-     + 'either from <code>localhost</code> or an <code>https</code> domain.';
+     + ' sure that your browser supports it, make sure your app is being served from a secure context, '
+     + 'either <code>localhost</code> or an <code>https</code> domain.';
   }
 };
 


### PR DESCRIPTION
[JIRA Ticket](https://issues.corp.twilio.com/browse/JSDK-2867)
Added some more descriptions for the error code modal. according to error handling doc

**Not Allowed Error**: 
![image](https://user-images.githubusercontent.com/43423318/86960753-d7aa7280-c114-11ea-9f7c-7c28a1d1f84e.png)

**NotFoundError**
NOTE: Used `simulateGetUserMediaError` for this. 
![image](https://user-images.githubusercontent.com/43423318/86992548-989d1100-c156-11ea-9d56-9549af380823.png)

**NotReadableError**
NOTE: I can only get this to display on select room
![image](https://user-images.githubusercontent.com/43423318/86982810-fe7d9e80-c13e-11ea-8f17-a1c42d7376c9.png)

**TypeError**
![image](https://user-images.githubusercontent.com/43423318/86971882-d124f680-c126-11ea-9cd9-c449aa42cff0.png)

**OverconstrainedError**
NOTE: Used `simulateGetUserMediaError` for this. 
![image](https://user-images.githubusercontent.com/43423318/86992805-3395eb00-c157-11ea-87d5-777d505110ab.png)
![image](https://user-images.githubusercontent.com/43423318/86993134-1281ca00-c158-11ea-80a3-78ee3c6f3f50.png)



**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
