### PR TITLE
JSDK-3015 Adding in CDN for mute/unmute icons

### DIFF
--- a/examples/localmediacontrols/public/index.html
+++ b/examples/localmediacontrols/public/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Enabling and Disabling Tracks</title>
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.2/css/all.css" integrity="sha384-vSIIfh2YWi9wW0r9iZe7RJPrKwp6bG+s9QZMoITbCckVJqGCCRhc+ccxNcdpHuYu" crossorigin="anonymous">
   <link rel="stylesheet" href="prism.css">
   <link rel="stylesheet" href="index.css">
 </head>


### PR DESCRIPTION
JIRA Ticket : [JSDK-3015](https://issues.corp.twilio.com/browse/JSDK-3015)

Fixing the enable and disable icons. Font Awesome updated to v5.0+ but they still allow free users to use free CDN.
![EnableDisableFix](https://user-images.githubusercontent.com/43423318/106051501-607f0080-609d-11eb-8f19-e4ff6e46d10b.gif)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
