### PR TITLE
JSDK-3564 - Adding Remote view in screen share example

### DIFF
--- a/examples/screenshare/public/index.html
+++ b/examples/screenshare/public/index.html
@@ -38,6 +38,12 @@
             <button id="stopscreencapture" class="btn btn-primary btn-block">Stop Screen Capture</button>
           </div>
         </div>
+        <div class="card-block">
+          <h4 class="card-title">Remote Screen</h4>
+          <div id="screenshare" class="card-body">
+            <video id="screenpreview" class="remote-screenpreview" autoplay></video>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/examples/screenshare/src/helpers.js
+++ b/examples/screenshare/src/helpers.js
@@ -7,9 +7,9 @@ const Video = require('twilio-video');
  * to other Participants in the Room.
  * @param {number} height - Desired vertical resolution in pixels
  * @param {number} width - Desired horizontal resolution in pixels
- * @returns {MediaStream}
+ * @returns {Promise<LocalVideoTrack>}
  */
-function createScreenStream(height, width) {
+function createScreenTrack(height, width) {
   if (typeof navigator === 'undefined'
     || !navigator.mediaDevices
     || !navigator.mediaDevices.getDisplayMedia) {
@@ -20,7 +20,9 @@ function createScreenStream(height, width) {
       height: height,
       width: width
     }
-  })
+  }).then(function(stream) {
+    return new Video.LocalVideoTrack(stream.getVideoTracks()[0]);
+  });
 }
 
-exports.createScreenStream = createScreenStream;
+exports.createScreenTrack = createScreenTrack;

--- a/examples/screenshare/src/helpers.js
+++ b/examples/screenshare/src/helpers.js
@@ -3,13 +3,13 @@
 const Video = require('twilio-video');
 
 /**
- * Create a LocalVideoTrack for your screen. You can then share it
- * with other Participants in the Room.
+ * Create a screen track for your screen. You can then publish it
+ * to other Participants in the Room.
  * @param {number} height - Desired vertical resolution in pixels
  * @param {number} width - Desired horizontal resolution in pixels
- * @returns {Promise<LocalVideoTrack>}
+ * @returns {MediaStream}
  */
-function createScreenTrack(height, width) {
+function createScreenStream(height, width) {
   if (typeof navigator === 'undefined'
     || !navigator.mediaDevices
     || !navigator.mediaDevices.getDisplayMedia) {
@@ -20,9 +20,7 @@ function createScreenTrack(height, width) {
       height: height,
       width: width
     }
-  }).then(function(stream) {
-    return new Video.LocalVideoTrack(stream.getVideoTracks()[0]);
-  });
+  })
 }
 
-exports.createScreenTrack = createScreenTrack;
+exports.createScreenStream = createScreenStream;

--- a/examples/screenshare/src/helpers.js
+++ b/examples/screenshare/src/helpers.js
@@ -3,8 +3,8 @@
 const Video = require('twilio-video');
 
 /**
- * Create a screen track for your screen. You can then publish it
- * to other Participants in the Room.
+ * Create a LocalVideoTrack for your screen. You can then share it
+ * with other Participants in the Room.
  * @param {number} height - Desired vertical resolution in pixels
  * @param {number} width - Desired horizontal resolution in pixels
  * @returns {Promise<LocalVideoTrack>}

--- a/examples/screenshare/src/index.js
+++ b/examples/screenshare/src/index.js
@@ -81,11 +81,11 @@ const remoteScreenPreview = document.querySelector('video.remote-screenpreview')
   // Remote Participant handles screen share track
   if(roomRemote) {
     roomRemote.on('trackPublished', publication => {
-      trackPublish('publish', publication, remoteScreenPreview);
+      trackPublishedHandler('publish', publication, remoteScreenPreview);
     });
 
     roomRemote.on('trackUnpublished', publication => {
-      trackPublish('unpublish', publication, remoteScreenPreview);
+      trackPublishedHandler('unpublish', publication, remoteScreenPreview);
     });
   }
 
@@ -107,7 +107,7 @@ function toggleButtons() {
   stopScreenCapture.style.display = stopScreenCapture.style.display === 'none' ? '' : 'none';
 }
 
-function trackPublish(publishType, publication, view) {
+function trackPublishedHandler(publishType, publication, view) {
   if (publishType === 'publish') {
     if (publication.track) {
       publication.track.attach(view);

--- a/examples/screenshare/src/index.js
+++ b/examples/screenshare/src/index.js
@@ -38,7 +38,6 @@ const remoteScreenPreview = document.querySelector('video.remote-screenpreview')
 
   // The LocalVideoTrack for your screen.
   let screenTrack;
-  // let localScreenTrack;
 
   captureScreen.onclick = async function() {
     try {
@@ -65,9 +64,7 @@ const remoteScreenPreview = document.querySelector('video.remote-screenpreview')
   };
 
   // Stop capturing your screen.
-  const stopScreenSharing = () => {
-    screenTrack.stop();
-  };
+  const stopScreenSharing = () => screenTrack.stop();
 
   stopScreenCapture.onclick = stopScreenSharing;
 

--- a/examples/screenshare/src/index.js
+++ b/examples/screenshare/src/index.js
@@ -46,7 +46,6 @@ const remoteScreenPreview = document.querySelector('video.remote-screenpreview')
       screenTrack = await createScreenTrack(720, 1280);
       screenTrack.attach(screenPreview);
 
-
       // Publish screen track to room
       await roomLocal.localParticipant.publishTrack(screenTrack);
 

--- a/examples/screenshare/src/index.js
+++ b/examples/screenshare/src/index.js
@@ -38,28 +38,25 @@ const remoteScreenPreview = document.querySelector('video.remote-screenpreview')
 
   // The LocalVideoTrack for your screen.
   let screenTrack;
-  let localScreenTrack;
+  // let localScreenTrack;
 
   captureScreen.onclick = async function() {
     try {
       // Create and preview your local screen.
       screenTrack = await createScreenTrack(720, 1280);
+      screenTrack.attach(screenPreview);
+
 
       // Publish screen track to room
-      await roomLocal.localParticipant.publishTrack(screenTrack, {
-        priority: 'low',
-      }).then (trackPublication => {
-        localScreenTrack = trackPublication.track;
-        trackPublication.track.attach(screenPreview);
-      });
+      await roomLocal.localParticipant.publishTrack(screenTrack);
 
-      // Show the "Capture Screen" button after screen capture stops.
-      localScreenTrack.on('stopped', () => {
-        stopScreenSharing
+      // When screen sharing is stopped, unpublish the screen track.
+      screenTrack.on('stopped', () => {
+        if (roomLocal) {
+          roomLocal.localParticipant.unpublishTrack(screenTrack);
+        }
+        toggleButtons();
       });
-
-      // Listening to on ended event on the MediaStreamTrack.
-      screenTrack.mediaStreamTrack.onended = stopScreenSharing;
 
       // Show the "Stop Capture Screen" button.
       toggleButtons();
@@ -70,9 +67,7 @@ const remoteScreenPreview = document.querySelector('video.remote-screenpreview')
 
   // Stop capturing your screen.
   const stopScreenSharing = () => {
-    roomLocal.localParticipant.unpublishTrack(screenTrack);
     screenTrack.stop();
-    toggleButtons();
   };
 
   stopScreenCapture.onclick = stopScreenSharing;

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "prismjs": "^1.6.0",
     "stackblur-canvas": "^1.4.0",
     "twilio": "^3.19.1",
-    "twilio-video": "^2.7.2"
+    "twilio-video": "^2.11.0"
   },
   "devDependencies": {
     "browserify": "^14.3.0",

--- a/quickstart/src/index.js
+++ b/quickstart/src/index.js
@@ -36,9 +36,6 @@ const connectOptions = {
   // https://www.twilio.com/console/video/configure
   dominantSpeaker: true,
 
-  // Comment this line to disable verbose logging.
-  logLevel: 'debug',
-
   // Comment this line if you are playing music.
   maxAudioBitrate: 16000,
 

--- a/quickstart/src/joinroom.js
+++ b/quickstart/src/joinroom.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { connect, createLocalVideoTrack } = require('twilio-video');
+const { connect, createLocalVideoTrack, Logger } = require('twilio-video');
 const { isMobile } = require('./browser');
 
 const $leave = $('#leave-room');
@@ -218,6 +218,10 @@ function trackPublished(publication, participant) {
  * @param connectOptions - the ConnectOptions used to join a Room
  */
 async function joinRoom(token, connectOptions) {
+  // Comment the next two lines to disable verbose logging.
+  const logger = Logger.getLogger('twilio-video');
+  logger.setLevel('debug');
+
   // Join to the Room with the given AccessToken and ConnectOptions.
   const room = await connect(token, connectOptions);
 


### PR DESCRIPTION
JIRA Ticket : [JSDK-3564](https://issues.corp.twilio.com/browse/VIDEO-3564)

In this PR I've added the remote participant view and adjusted the helper function a bit since I need access to the Media Stream in order to catch the `onended` event from when we stop sharing out of view. I have also gone ahead and updated the Twilio-Video package to use 2.11.0.

![ScreenShare](https://user-images.githubusercontent.com/43423318/107282828-63b8ab80-6a10-11eb-9187-a28e5702ad21.gif)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
