### PR TITLE
VIDEO-3563 Small patch to fix audio level indicator

### DIFF
--- a/quickstart/src/index.js
+++ b/quickstart/src/index.js
@@ -117,9 +117,9 @@ async function selectAndJoinRoom(error = null) {
 async function selectCamera() {
   if (deviceIds.video === null) {
     try {
-      deviceIds.video = await selectMedia('video', $selectCameraModal, stream => {
+      deviceIds.video = await selectMedia('video', $selectCameraModal, videoTrack => {
         const $video = $('video', $selectCameraModal);
-        $video.get(0).srcObject = stream;
+        videoTrack.attach($video.get(0))
       });
     } catch (error) {
       showError($showErrorModal, error);
@@ -135,10 +135,10 @@ async function selectCamera() {
 async function selectMicrophone() {
   if (deviceIds.audio === null) {
     try {
-      deviceIds.audio = await selectMedia('audio', $selectMicModal, stream => {
+      deviceIds.audio = await selectMedia('audio', $selectMicModal, audioTrack => {
         const $levelIndicator = $('svg rect', $selectMicModal);
         const maxLevel = Number($levelIndicator.attr('height'));
-        micLevel(stream, maxLevel, level => $levelIndicator.attr('y', maxLevel - level));
+        micLevel(audioTrack, maxLevel, level => $levelIndicator.attr('y', maxLevel - level));
       });
     } catch (error) {
       showError($showErrorModal, error);

--- a/quickstart/src/selectmedia.js
+++ b/quickstart/src/selectmedia.js
@@ -25,7 +25,7 @@ async function applyInputDevice(kind, deviceId, render) {
 
   // Render the current LocalTrack.
   localTracks[kind] = track;
-  render(new MediaStream([track.mediaStreamTrack]));
+  render(track);
 }
 
 /**


### PR DESCRIPTION
JIRA Ticket : [VIDEO-3563](https://issues.corp.twilio.com/browse/VIDEO-3563)

This is a small patch to the audio level indicator breaking on iOS safari. The fix is now we are passing in the audio track rather than the stream so we can access the new media stream from the `track` that was restarted when silence is detected. 

![image](https://user-images.githubusercontent.com/43423318/107715553-628fb480-6c84-11eb-8d1e-04d8e528e5e5.png)

Please refer to the JIRA ticket of the working fix. 

There are some caveats to this fix, if a user decided to close and open the tab multiple times (3+) the indicator will break. However, this is a corner case that should not happen under normal circumstances.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
