### PR TITLE
VIDEO-3525 - Adopt VideoProcessor API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,7 @@ examples/datatracks/public/index.js
 examples/bandwidthconstraints/public/helpers.js
 examples/codecpreferences/public/helpers.js
 examples/dominantspeaker/public/helpers.js
-examples/localvideofilter/public/helpers.js
+examples/localvideofilter/public/helpers*.js
 examples/localvideosnapshot/public/helpers.js
 examples/mediadevices/public/helpers.js
 examples/networkquality/public/helpers.js

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-**NEW:** Please check out our [Best Practices Guide](https://www.twilio.com/docs/video/build-js-video-application-recommendations-and-best-practices)
-for building video applications with twilio-video.js.
+**NEW:** The [Local Video Filter](examples/localvideofilter) example has been updated to use the recently released [Video Processor API](https://github.com/twilio/twilio-video.js/releases/tag/2.13.0) for Chrome.
 
 # Twilio Video Quickstart for JavaScript
 

--- a/examples/localvideofilter/src/filters.js
+++ b/examples/localvideofilter/src/filters.js
@@ -26,7 +26,7 @@ function grayscale(imageData) {
     var r = data[i];
     var g = data[i + 1];
     var b = data[i + 2];
-    var gs = ((0.2126 * r) + (0.7152 * g) + (0.0722 * b)) / 3;
+    var gs = (r + g + b) / 3;
     data[i] = data[i + 1] = data[i + 2] = gs;
   }
   return imageData;

--- a/examples/localvideofilter/src/helpers-video-processor.js
+++ b/examples/localvideofilter/src/helpers-video-processor.js
@@ -1,0 +1,77 @@
+'use strict';
+
+var Video = require('twilio-video');
+
+/**
+ * Apply a filter to the frames of a LocalVideoTrack.
+ * @param {number} width - Width in pixels of the video frames
+ * @param {number} height - Height in pixels of the video frames
+ * @param {'blur' | 'grayscale' | 'sepia'} name - Filter name
+ * @param {string} settingValue - Filter setting value
+ * @constructor
+ */
+function FilterVideoProcessor(width, height, name, settingValue) {
+  this._outputFrame = new OffscreenCanvas(width, height);
+  this._outputContext = this._outputFrame.getContext('2d');
+  this._outputContext.filter = name + '(' + settingValue + ')';
+}
+
+/**
+ * Process a frame of the LocalVideoTrack.
+ * @param {OffscreenCanvas} inputFrame
+ * @returns {OffscreenCanvas}
+ */
+FilterVideoProcessor.prototype.processFrame = function processFrame(inputFrame) {
+  this._outputContext.drawImage(inputFrame, 0, 0);
+  return this._outputFrame;
+};
+
+/**
+ * Display local video in the given HTMLVideoElement.
+ * @param {HTMLVideoElement} video
+ * @returns {Promise<void>}
+ */
+function displayLocalVideo(video) {
+  return Video.createLocalVideoTrack({
+    width: 640,
+    height: 360
+  }).then(function(localTrack) {
+    localTrack.attach(video);
+  });
+}
+
+/**
+ * The filtered LocalVideoTrack;
+ */
+var filteredLocalTrack;
+
+/**
+ * Apply the specified filter to the local video.
+ * @param {HTMLVideoElement} video - Raw video
+ * @param {HTMLVideoElement} filtered - Filtered video
+ * @param {'none' | 'blur' | 'grayscale' | 'sepia'} name - Filter name
+ */
+function filterLocalVideo(video, filtered, name) {
+  if (!filteredLocalTrack) {
+    var mediaStreamTrack = video.srcObject.getVideoTracks()[0];
+    filteredLocalTrack = new Video.LocalVideoTrack(mediaStreamTrack);
+    filteredLocalTrack.attach(filtered);
+  }
+
+  var processor = filteredLocalTrack.processor;
+  if (processor) {
+    filteredLocalTrack.removeProcessor(processor);
+  }
+
+  if (name !== 'none') {
+    var value = name === 'blur' ? '5px' : '100%';
+    var settings = filteredLocalTrack.mediaStreamTrack.getSettings();
+    var height = settings.height;
+    var width = settings.width;
+    processor = new FilterVideoProcessor(width, height, name, value);
+    filteredLocalTrack.addProcessor(processor);
+  }
+}
+
+module.exports.displayLocalVideo = displayLocalVideo;
+module.exports.filterLocalVideo = filterLocalVideo;

--- a/examples/localvideofilter/src/helpers-video-processor.js
+++ b/examples/localvideofilter/src/helpers-video-processor.js
@@ -6,14 +6,13 @@ var Video = require('twilio-video');
  * Apply a filter to the frames of a LocalVideoTrack.
  * @param {number} width - Width in pixels of the video frames
  * @param {number} height - Height in pixels of the video frames
- * @param {'blur' | 'grayscale' | 'sepia'} name - Filter name
- * @param {string} settingValue - Filter setting value
+ * @param {string} filterCSS - Filter CSS string
  * @constructor
  */
-function FilterVideoProcessor(width, height, name, settingValue) {
+function FilterVideoProcessor(width, height, filterCSS) {
   this._outputFrame = new OffscreenCanvas(width, height);
   this._outputContext = this._outputFrame.getContext('2d');
-  this._outputContext.filter = name + '(' + settingValue + ')';
+  this._outputContext.filter = filterCSS;
 }
 
 /**
@@ -64,11 +63,11 @@ function filterLocalVideo(video, filtered, name) {
   }
 
   if (name !== 'none') {
-    var value = name === 'blur' ? '5px' : '100%';
+    var filterCSS = name + '(' + (name === 'blur' ? '5px' : '100%') + ')';
     var settings = filteredLocalTrack.mediaStreamTrack.getSettings();
     var height = settings.height;
     var width = settings.width;
-    processor = new FilterVideoProcessor(width, height, name, value);
+    processor = new FilterVideoProcessor(width, height, filterCSS);
     filteredLocalTrack.addProcessor(processor);
   }
 }

--- a/examples/localvideofilter/src/helpers.js
+++ b/examples/localvideofilter/src/helpers.js
@@ -3,19 +3,25 @@
 var Video = require('twilio-video');
 var filters = require('./filters');
 
-var VIDEO_WIDTH = 320;
-var VIDEO_HEIGHT = 240;
-
 /**
  * Display local video in the given HTMLVideoElement.
  * @param {HTMLVideoElement} video
  * @returns {Promise<void>}
  */
 function displayLocalVideo(video) {
-  return Video.createLocalVideoTrack().then(function(localTrack) {
+  return Video.createLocalVideoTrack({
+    width: 640,
+    height: 360
+  }).then(function(localTrack) {
     localTrack.attach(video);
   });
 }
+
+/**
+ * The timeout for filtering a video frame.
+ * @type {number}
+ */
+var filterTimeout;
 
 /**
  * Apply the specified filter to the local video.
@@ -25,20 +31,34 @@ function displayLocalVideo(video) {
  */
 function filterLocalVideo(video, filtered, name) {
   var canvas = document.createElement('canvas');
+  var mediaStreamTrack = video.srcObject.getVideoTracks()[0];
+  var settings = mediaStreamTrack.getSettings();
+  canvas.width = settings.width;
+  canvas.height = settings.height;
+
   var context = canvas.getContext('2d');
-  canvas.width = VIDEO_WIDTH;
-  canvas.height = VIDEO_HEIGHT;
+  var filterValue = name === 'blur' ? '5px' : '100%';
+  context.filter = name === 'none' ? '' : name + '(' + filterValue + ')';
+  clearTimeout(filterTimeout);
+
+  var isSafari = /Safari/.test(navigator.userAgent)
+    && !/Chrome/.test(navigator.userAgent);
 
   function filterVideoFrame() {
-    context.drawImage(video, 0, 0, canvas.width, canvas.height);
-    var imageData = context.getImageData(0, 0, canvas.width, canvas.height);
-    context.putImageData(filters[name](imageData), 0, 0);
-    requestAnimationFrame(filterVideoFrame);
+    var renderStartTime = Date.now();
+    context.drawImage(video, 0, 0);
+    if (isSafari) {
+      var imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+      context.putImageData(filters[name](imageData), 0, 0);
+    }
+    var renderDelay = Date.now() - renderStartTime;
+    var interFrameDelay = Math.round(1000 / settings.frameRate);
+    filterTimeout = setTimeout(filterVideoFrame, interFrameDelay - renderDelay);
   }
 
-  var stream = canvas.captureStream(30);
+  var stream = canvas.captureStream(settings.frameRate);
   filtered.srcObject = stream;
-  requestAnimationFrame(filterVideoFrame);
+  filterTimeout = setTimeout(filterVideoFrame);
 }
 
 module.exports.displayLocalVideo = displayLocalVideo;

--- a/examples/localvideofilter/src/index.js
+++ b/examples/localvideofilter/src/index.js
@@ -2,7 +2,11 @@
 
 var Prism = require('prismjs');
 var getSnippet = require('../../util/getsnippet');
-var helpers = require('./helpers');
+
+var helpers = typeof OffscreenCanvas === 'undefined'
+  ? require('./helpers')
+  : require('./helpers-video-processor');
+
 var displayLocalVideo = helpers.displayLocalVideo;
 var filterLocalVideo = helpers.filterLocalVideo;
 
@@ -11,7 +15,11 @@ var video = document.querySelector('video#videoinputpreview');
 var filtered = document.querySelector('video#videoinputfiltered');
 
 // Load the code snippet.
-getSnippet('./helpers.js').then(function(snippet) {
+getSnippet(
+  typeof OffscreenCanvas === 'undefined'
+    ? './helpers.js'
+    : './helpers-video-processor.js'
+).then(function(snippet) {
   var pre = document.querySelector('pre.language-javascript');
   pre.innerHTML = Prism.highlight(snippet, Prism.languages.javascript);
 });

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:examples:bandwidthconstraints": "copyfiles -f examples/bandwidthconstraints/src/helpers.js examples/bandwidthconstraints/public && browserify examples/bandwidthconstraints/src/index.js > examples/bandwidthconstraints/public/index.js",
     "build:examples:codecpreferences": "copyfiles -f examples/codecpreferences/src/helpers.js examples/codecpreferences/public && browserify examples/codecpreferences/src/index.js > examples/codecpreferences/public/index.js",
     "build:examples:dominantspeaker": "copyfiles -f examples/dominantspeaker/src/helpers.js examples/dominantspeaker/public && browserify examples/dominantspeaker/src/index.js > examples/dominantspeaker/public/index.js",
-    "build:examples:localvideofilter": "copyfiles -f examples/localvideofilter/src/helpers.js examples/localvideofilter/public && browserify examples/localvideofilter/src/index.js > examples/localvideofilter/public/index.js",
+    "build:examples:localvideofilter": "copyfiles -f examples/localvideofilter/src/helpers*.js examples/localvideofilter/public && browserify examples/localvideofilter/src/index.js > examples/localvideofilter/public/index.js",
     "build:examples:localvideosnapshot": "copyfiles -f examples/localvideosnapshot/src/helpers.js examples/localvideosnapshot/public && browserify examples/localvideosnapshot/src/index.js > examples/localvideosnapshot/public/index.js",
     "build:examples:mediadevices": "copyfiles -f examples/mediadevices/src/helpers.js examples/mediadevices/public && browserify examples/mediadevices/src/index.js > examples/mediadevices/public/index.js",
     "build:examples:networkquality": "copyfiles -f examples/networkquality/src/helpers.js examples/networkquality/public && browserify examples/networkquality/src/index.js > examples/networkquality/public/index.js",
@@ -24,7 +24,7 @@
     "clean:examples:bandwidthconstraints": "rimraf examples/bandwidthconstraints/public/index.js examples/bandwidthconstraints/public/helpers.js",
     "clean:examples:codecpreferences": "rimraf examples/codecpreferences/public/index.js examples/codecpreferences/public/helpers.js",
     "clean:examples:dominantspeaker": "rimraf examples/dominantspeaker/public/index.js examples/dominantspeaker/public/helpers.js",
-    "clean:examples:localvideofilter": "rimraf examples/localvideofilter/public/index.js examples/localvideofilter/public/helpers.js",
+    "clean:examples:localvideofilter": "rimraf examples/localvideofilter/public/index.js examples/localvideofilter/public/helpers*.js",
     "clean:examples:localvideosnapshot": "rimraf examples/localvideosnapshot/public/index.js examples/localvideosnapshot/public/helpers.js",
     "clean:examples:mediadevices": "rimraf examples/mediadevices/public/index.js examples/mediadevices/public/helpers.js",
     "clean:examples:networkquality": "rimraf examples/networkquality/public/index.js examples/networkquality/public/helpers.js",
@@ -61,7 +61,7 @@
     "prismjs": "^1.6.0",
     "stackblur-canvas": "^1.4.0",
     "twilio": "^3.19.1",
-    "twilio-video": "^2.11.0"
+    "twilio-video": "^2.13.0"
   },
   "devDependencies": {
     "browserify": "^14.3.0",


### PR DESCRIPTION
@charliesantos @PikaJoyce 

This PR contains the following changes:

* Updating Local Video Filter example to use the VideoProcessor API on Chrome.
* Refactoring the example for Firefox and Safari to remove inefficiencies.
* Updating README.md to highlight the VideoProcessor API.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
