### PR TITLE
VIDEO-5326 Removing renderConnectOptions replacing with new hints config

### DIFF
--- a/quickstart/src/index.js
+++ b/quickstart/src/index.js
@@ -24,10 +24,8 @@ const connectOptions = {
     video: {
       dominantSpeakerPriority: 'high',
       mode: 'collaboration',
-      renderDimensions: {
-        high: { height: 720, width: 1280 },
-        standard: { height: 90, width: 160 }
-      }
+      clientTrackSwitchOffControl: 'auto',
+      contentPreferencesMode: 'auto'
     }
   },
 


### PR DESCRIPTION
JIRA Ticket : [VIDEO-5326](https://issues.corp.twilio.com/browse/VIDEO-5326)

I've added the new config connect options. However, according to the ticket, I wasn't able to find a `maxTracks` property.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
