### PR TITLE
VIDEO-6370 - Clean up detached track elements

### DIFF
--- a/examples/bandwidthconstraints/src/index.js
+++ b/examples/bandwidthconstraints/src/index.js
@@ -53,6 +53,7 @@ function attachTrack(audioElement, videoElement, starAudioBitrateGraph, startVid
  */
 function detachAudioTrack(track, audioElement) {
   track.detach(audioElement);
+  audioElement.srcObject = null;
   waveform.unsetStream();
   const canvas = waveformContainer.querySelector('canvas');
   if (canvas) {
@@ -70,6 +71,7 @@ function detachTrack(audioElement, videoElement, track) {
     return;
   }
   track.detach(videoElement);
+  videoElement.srcObject = null;
   stopVideoBitrateGraph();
 }
 

--- a/examples/codecpreferences/src/index.js
+++ b/examples/codecpreferences/src/index.js
@@ -48,6 +48,7 @@ function attachTrack(audioElement, videoElement, showAppliedCodec, track) {
  */
 function detachAudioTrack(track, audioElement) {
   track.detach(audioElement);
+  audioElement.srcObject = null;
   waveform.unsetStream();
   const canvas = waveformContainer.querySelector('canvas');
   if (canvas) {
@@ -65,6 +66,7 @@ function detachTrack(audioElement, videoElement, track) {
     return;
   }
   track.detach(videoElement);
+  videoElement.srcObject = null;
 }
 
 /**

--- a/examples/dominantspeaker/src/index.js
+++ b/examples/dominantspeaker/src/index.js
@@ -165,6 +165,7 @@ function updateDominantSpeaker(speaker) {
   someRoom.on('participantDisconnected', function(participant) {
     getTracks(participant).forEach(function(track) {
       track.detach().forEach(function(element) {
+        element.srcObject = null;
         element.remove();
       });
     });

--- a/examples/localmediacontrols/src/index.js
+++ b/examples/localmediacontrols/src/index.js
@@ -87,6 +87,7 @@ let roomName = null;
 
   participantMutedOrUnmutedMedia(roomP2, track => {
     track.detach().forEach(element => {
+      element.srcObject = null;
       element.remove();
     });
   }, track => {

--- a/examples/mediadevices/src/index.js
+++ b/examples/mediadevices/src/index.js
@@ -73,6 +73,7 @@ function attachTrack(track, container) {
 // Detach given track from the DOM
 function detachTrack(track) {
   track.detach().forEach(function(element) {
+    element.srcObject = null;
     element.remove();
   });
 }

--- a/examples/screenshare/src/index.js
+++ b/examples/screenshare/src/index.js
@@ -109,10 +109,12 @@ function onTrackPublished(publishType, publication, view) {
   } else if (publishType === 'unpublish') {
     if (publication.track) {
       publication.track.detach(view);
+      view.srcObject = null;
     }
 
     publication.on('subscribed', track => {
       track.detach(view);
+      view.srcObject = null;
     });
   }
 }

--- a/quickstart/src/joinroom.js
+++ b/quickstart/src/joinroom.js
@@ -142,13 +142,17 @@ function attachTrack(track, participant) {
 function detachTrack(track, participant) {
   // Detach the Participant's Track from the thumbnail.
   const $media = $(`div#${participant.sid} > ${track.kind}`, $participants);
+  const mediaEl = $media.get(0);
   $media.css('opacity', '0');
-  track.detach($media.get(0));
+  track.detach(mediaEl);
+  mediaEl.srcObject = null;
 
   // If the detached Track is a VideoTrack that is published by the active
   // Participant, then detach it from the main video as well.
   if (track.kind === 'video' && participant === activeParticipant) {
-    track.detach($activeVideo.get(0));
+    const activeVideoEl = $activeVideo.get(0);
+    track.detach(activeVideoEl);
+    activeVideoEl.srcObject = null;
     $activeVideo.css('opacity', '0');
   }
 }


### PR DESCRIPTION
Fix for Chrome 92 issue:
Clean up the room's elements when a track is detached.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
