### PR TITLE
VIDEO-7710 - Fixing Media Device Selection for Audio Output

### DIFF
--- a/examples/mediadevices/public/index.html
+++ b/examples/mediadevices/public/index.html
@@ -33,7 +33,6 @@
           <div class="card-block">
             <h4 class="card-title">Preview Media</h4>
             <div id="audioinputwaveform"></div>
-            <audio id="audioinputpreview" autoplay></audio>
             <video id="videoinputpreview" autoplay></video>
           </div>
         </div>

--- a/examples/mediadevices/src/index.js
+++ b/examples/mediadevices/src/index.js
@@ -153,15 +153,25 @@ async function applyVideoInputDeviceChange(event) {
 
 // reads selected audio output, and updates preview to use the device.
 function applyAudioOutputDeviceChange(event) {
-  var audio = document.querySelector('audio#audioinputpreview');
-
-  // Note: not supported on safari
-  if (deviceSelections.audiooutput.value) {
-    applyAudioOutputDeviceSelection(deviceSelections.audiooutput.value, audio);
+  if (event) {
+    event.preventDefault();
+    event.stopPropagation();
   }
-
-  event.preventDefault();
-  event.stopPropagation();
+  let deviceId = deviceSelections.audiooutput.value;
+  let outputDevice = deviceSelections.audiooutput.options[audiooutput.selectedIndex].value;
+  document.querySelectorAll('audio').forEach(audioEl => {
+    if (deviceId) {
+      // Note: not supported on safari
+      applyAudioOutputDeviceSelection(deviceId, audioEl)
+        .then(() => {
+          console.log(`Success, audio output device attached: ${deviceId} for ${outputDevice}`);
+        })
+        .catch(error => {
+          let errorMessage = error;
+          console.error('ERROR: ', errorMessage);
+        });
+    }
+  })
 }
 
 function maybeEnableConnectButton() {

--- a/examples/mediadevices/src/index.js
+++ b/examples/mediadevices/src/index.js
@@ -15,6 +15,7 @@ const roomNameText = document.querySelector('#roomName');
 let someRoom = null;
 let localAudioTrack = null;
 let localVideoTrack = null;
+let deviceId;
 
 var getDeviceSelectionOptions = helpers.getDeviceSelectionOptions;
 
@@ -67,7 +68,15 @@ function updateRoomBlock(room) {
 
 // Attach the Track to the DOM.
 function attachTrack(track, container) {
-  container.appendChild(track.attach());
+  let audioEl;
+  if (track.kind === 'audio') {
+    audioEl = track.attach();
+    audioEl.className = 'remote-audio'
+    deviceId ? applyAudioOutputDeviceSelection(deviceId, audioEl) : null;
+    container.appendChild(audioEl)
+  } else {
+    container.appendChild(track.attach());
+  }
 }
 
 // Detach given track from the DOM
@@ -155,16 +164,14 @@ async function applyVideoInputDeviceChange(event) {
 function applyAudioOutputDeviceChange(event) {
   if (event) {
     event.preventDefault();
-    event.stopPropagation();
   }
-  let deviceId = deviceSelections.audiooutput.value;
-  let outputDevice = deviceSelections.audiooutput.options[audiooutput.selectedIndex].value;
-  document.querySelectorAll('audio').forEach(audioEl => {
+  deviceId = deviceSelections.audiooutput.value;
+  document.querySelectorAll('.remote-audio').forEach(audioEl => {
     if (deviceId) {
       // Note: not supported on safari
       applyAudioOutputDeviceSelection(deviceId, audioEl)
         .then(() => {
-          console.log(`Success, audio output device attached: ${deviceId} for ${outputDevice}`);
+          console.log(`Success, audio output device attached: ${deviceId}`);
         })
         .catch(error => {
           let errorMessage = error;


### PR DESCRIPTION
JIRA Ticket : [VIDEO-7710](https://issues.corp.twilio.com/browse/VIDEO-7710)

This PR addresses the audio output selection not working, prior to this fix, we were using `setSinkId` on an inactive audio element. The change applies `setSinkId` on all audio elements from the remote participants coming in.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
