### PR TITLE
Update browserify version to fix complie error

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,11 +64,11 @@
     "express": "^4.15.2",
     "prismjs": "^1.6.0",
     "stackblur-canvas": "^1.4.0",
-    "twilio": "^3.19.1",
-    "twilio-video": "^2.18.0"
+    "twilio": "^3.80.1",
+    "twilio-video": "^2.23.0"
   },
   "devDependencies": {
-    "browserify": "^14.3.0",
+    "browserify": "^17.0.0",
     "copyfiles": "^1.2.0",
     "npm-run-all": "^4.0.2",
     "rimraf": "^2.6.1"


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

This PR updates some dependencies for this quickstart. Most notably it updates the `browserify` version, which was causing the issue reported here: #213 

By upgrading the `browserify` version, the quickstart no longer throws an error during the build step.
