### PR TITLE
Remove maxAudioBitrate: 16000 from quickstart connect options

### DIFF
--- a/examples/dominantspeaker/src/helpers.js
+++ b/examples/dominantspeaker/src/helpers.js
@@ -4,7 +4,7 @@ var Video = require('twilio-video');
 
 /**
  * Connect to a Room with the Dominant Speaker API enabled.
- * This API is available only in Small Group or Group Rooms.
+ * This API is available only in Group Rooms.
  * @param {string} token - Token for joining the Room
  * @returns {CancelablePromise<Room>}
  */

--- a/examples/index.html
+++ b/examples/index.html
@@ -117,9 +117,9 @@
             </a>
             <div class="card-block">
               <p class="card-text">
-                This app demonstrates the <a href="https://www.twilio.com/docs/video/detecting-dominant-speaker" target="_blank">Dominant Speaker API</a> for Group or Small Group Rooms.
+                This app demonstrates the <a href="https://www.twilio.com/docs/video/detecting-dominant-speaker" target="_blank">Dominant Speaker API</a> for Group Rooms.
                 In order to run this example, please go to the <a href="https://www.twilio.com/console/video/configure" target="_blank">Programmable Video Settings</a> in the
-                Twilio Console and select the Room Type as Group or Group-Small.
+                Twilio Console and select the Room Type as Group.
               </p>
             </div>
           </div>
@@ -149,9 +149,9 @@
             </a>
             <div class="card-block">
               <p class="card-text">
-                This app demonstrates the <a href="https://www.twilio.com/docs/video/using-network-quality-api" target="_blank">Network Quality API</a> for Group or Small Group Rooms.
+                This app demonstrates the <a href="https://www.twilio.com/docs/video/using-network-quality-api" target="_blank">Network Quality API</a> for Group Rooms.
                 In order to run this example, please go to the <a href="https://www.twilio.com/console/video/configure" target="_blank">Programmable Video Settings</a> in the
-                Twilio Console and select the Room Type as Group or Group-Small.
+                Twilio Console and select the Room Type as Group.
               </p>
             </div>
           </div>

--- a/examples/networkquality/src/helpers.js
+++ b/examples/networkquality/src/helpers.js
@@ -4,7 +4,7 @@ var Video = require('twilio-video');
 
 /**
  * Connect to a Room with the Network Quality API enabled.
- * This API is available only in Small Group or Group Rooms.
+ * This API is available only in Group Rooms.
  * @param {string} token - Token for joining the Room
  * @param {number} localVerbosity - Verbosity level of Network Quality reports
  *   for the LocalParticipant [1 - 3]

--- a/quickstart/src/index.js
+++ b/quickstart/src/index.js
@@ -17,9 +17,6 @@ const $joinRoomModal = $('#join-room', $modals);
 
 // ConnectOptions settings for a video web application.
 const connectOptions = {
-  // Available only in Group Rooms. Please set "Room Type"
-  // to "Group" in your Twilio Console:
-  // https://www.twilio.com/console/video/configure
   bandwidthProfile: {
     video: {
       dominantSpeakerPriority: 'high',

--- a/quickstart/src/index.js
+++ b/quickstart/src/index.js
@@ -34,9 +34,6 @@ const connectOptions = {
   // https://www.twilio.com/console/video/configure
   dominantSpeaker: true,
 
-  // Comment this line if you are playing music.
-  maxAudioBitrate: 16000,
-
   // VP8 simulcast enables the media server in a Small Group or Group Room
   // to adapt your encoded video quality for each RemoteParticipant based on
   // their individual bandwidth constraints. This has no utility if you are

--- a/quickstart/src/index.js
+++ b/quickstart/src/index.js
@@ -17,8 +17,8 @@ const $joinRoomModal = $('#join-room', $modals);
 
 // ConnectOptions settings for a video web application.
 const connectOptions = {
-  // Available only in Small Group or Group Rooms only. Please set "Room Type"
-  // to "Group" or "Small Group" in your Twilio Console:
+  // Available only in Group Rooms. Please set "Room Type"
+  // to "Group" in your Twilio Console:
   // https://www.twilio.com/console/video/configure
   bandwidthProfile: {
     video: {
@@ -29,12 +29,12 @@ const connectOptions = {
     }
   },
 
-  // Available only in Small Group or Group Rooms only. Please set "Room Type"
-  // to "Group" or "Small Group" in your Twilio Console:
+  // Available only in Group Rooms. Please set "Room Type"
+  // to "Group" in your Twilio Console:
   // https://www.twilio.com/console/video/configure
   dominantSpeaker: true,
 
-  // VP8 simulcast enables the media server in a Small Group or Group Room
+  // VP8 simulcast enables the media server in a Group Room
   // to adapt your encoded video quality for each RemoteParticipant based on
   // their individual bandwidth constraints. This has no utility if you are
   // using Peer-to-Peer Rooms, so you can comment this line.

--- a/quickstart/src/index.js
+++ b/quickstart/src/index.js
@@ -36,8 +36,7 @@ const connectOptions = {
 
   // VP8 simulcast enables the media server in a Group Room
   // to adapt your encoded video quality for each RemoteParticipant based on
-  // their individual bandwidth constraints. This has no utility if you are
-  // using Peer-to-Peer Rooms, so you can comment this line.
+  // their individual bandwidth constraints.
   preferredVideoCodecs: [{ codec: 'VP8', simulcast: true }],
 
   // Capture 720p video @ 24 fps.

--- a/quickstart/src/index.js
+++ b/quickstart/src/index.js
@@ -26,9 +26,6 @@ const connectOptions = {
     }
   },
 
-  // Available only in Group Rooms. Please set "Room Type"
-  // to "Group" in your Twilio Console:
-  // https://www.twilio.com/console/video/configure
   dominantSpeaker: true,
 
   // VP8 simulcast enables the media server in a Group Room

--- a/quickstart/src/joinroom.js
+++ b/quickstart/src/joinroom.js
@@ -107,8 +107,7 @@ function setupParticipantContainer(participant, room) {
 }
 
 /**
- * Set the VideoTrack priority for the given RemoteParticipant. This has no
- * effect in Peer-to-Peer Rooms.
+ * Set the VideoTrack priority for the given RemoteParticipant.
  * @param participant - the RemoteParticipant whose VideoTrack priority is to be set
  * @param priority - null | 'low' | 'standard' | 'high'
  */


### PR DESCRIPTION
<!-- Describe your Pull Request -->

VIDEO-14649: Leaving maxAudioBitrate unset lets Opus use its defaults (20-40 kbps) with more effective FEC.
Also remove references to legacy Room types. 

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
