### PR TITLE
Fix broken and outdated demos

### DIFF
--- a/examples/localvideofilter/src/helpers-video-processor.js
+++ b/examples/localvideofilter/src/helpers-video-processor.js
@@ -20,9 +20,10 @@ function FilterVideoProcessor(width, height, filterCSS) {
  * @param {OffscreenCanvas} inputFrame
  * @returns {OffscreenCanvas}
  */
-FilterVideoProcessor.prototype.processFrame = function processFrame(inputFrame) {
-  this._outputContext.drawImage(inputFrame, 0, 0);
-  return this._outputFrame;
+FilterVideoProcessor.prototype.processFrame = function processFrame(inputFrameBuffer, outputFrameBuffer) {
+  const context = outputFrameBuffer.getContext('2d');
+  context.filter = this._outputContext.filter; 
+  context.drawImage(inputFrameBuffer, 0, 0, inputFrameBuffer.width, inputFrameBuffer.height);
 };
 
 /**

--- a/examples/manualrenderhint/src/index.js
+++ b/examples/manualrenderhint/src/index.js
@@ -84,6 +84,7 @@ const handleIsSwitchedOff = (isTrackSwitchedOff) => {
       track.on('switchedOn', track => {
         handleIsSwitchedOff(track.isSwitchedOff);
       });
+      remoteVideoTrack = track;
     }
   });
 

--- a/examples/reconnection/src/helpers.js
+++ b/examples/reconnection/src/helpers.js
@@ -8,12 +8,14 @@
  */
 function setupReconnectionUpdates(room, updateRoomState) {
   room.on('disconnected', (room, error) => {
-    if (error.code === 20104) {
-      console.log('Signaling reconnection failed due to expired AccessToken!');
-    } else if (error.code === 53000) {
-      console.log('Signaling reconnection attempts exhausted!');
-    } else if (error.code === 53204) {
-      console.log('Signaling reconnection took too long!');
+    if (error) {
+	    if (error.code === 20104) {
+	      console.log('Signaling reconnection failed due to expired AccessToken!');
+	    } else if (error.code === 53000) {
+	      console.log('Signaling reconnection attempts exhausted!');
+	    } else if (error.code === 53204) {
+	      console.log('Signaling reconnection took too long!');
+	    }
     }
     updateRoomState(room.state);
   });
@@ -24,10 +26,12 @@ function setupReconnectionUpdates(room, updateRoomState) {
   });
 
   room.on('reconnecting', function(error) {
-    if (error.code === 53001) {
-      console.log('Reconnecting your signaling connection!', error.message);
-    } else if (error.code === 53405) {
-      console.log('Reconnecting your media connection!', error.message);
+    if (error) {
+	    if (error.code === 53001) {
+	      console.log('Reconnecting your signaling connection!', error.message);
+	    } else if (error.code === 53405) {
+	      console.log('Reconnecting your media connection!', error.message);
+	    }
     }
     updateRoomState(room.state);
   });


### PR DESCRIPTION
A few of the examples have drifted from the current Video SDK:

- "Local Video Filter" example has a mismatched signature for `processFrame` function on the `FilterVideoProcessor`. It now received the input and output as arguments rather than returning the output.
- "Manual Render Hint" example could not work, because the controls read from the `remoteVideoTrack` global, which is initialized to `null` and then never changed to anything else.
- "Reconnection States and Events" example reads `error.code` unconditionally, even if the event arrived with `error` of `null`.

Disclaimer:

- [x] I acknowledge that all my contributions will be made under the project's license.
